### PR TITLE
Add campaign knowledge base scaffold

### DIFF
--- a/00-campaign-frame/campaign-truths.md
+++ b/00-campaign-frame/campaign-truths.md
@@ -1,0 +1,22 @@
+# Campaign Truths
+
+## What This Is
+
+These are the setting assumptions that appear repeatedly across the knowledge base.
+
+## Truths
+
+1. Baldur's Gate survived the Absolute Crisis, but the scars remain visible in both stone and memory.
+2. Reconstruction empowered merchants, consortiums, guilds, and foreign enclaves as much as elected or hereditary government.
+3. The city is now a stronger trade hub and a weaker moral community.
+4. The Outer City matters more than before and cannot be treated as a disposable fringe.
+5. The Guild is not just a criminal network; for many residents it functions like government.
+6. Wealth shapes justice, safety, and political influence more openly than ever.
+7. Every stable institution is under pressure from at least one rival power center.
+8. The player characters enter a city that is already in motion, not waiting for them to activate it.
+
+## Related Notes
+
+- `premise.md`
+- `starting-situation.md`
+- `../10-setting/baldurs-gate-overview.md`

--- a/00-campaign-frame/content.md
+++ b/00-campaign-frame/content.md
@@ -1,0 +1,18 @@
+# Campaign Frame Contents
+
+## What Lives Here
+
+This folder defines the campaign at the highest level: premise, tone, assumptions, starting situation, and short briefs for players and the GM.
+
+## When To Use It
+
+Read this folder before diving into the setting. These notes explain what kind of game this is and what parts of Baldur's Gate matter most to the campaign.
+
+## Expected Notes
+
+- `premise.md`: the one-paragraph campaign pitch
+- `themes-and-tone.md`: the emotional and narrative style
+- `campaign-truths.md`: core truths that shape the setting
+- `starting-situation.md`: the state of play at campaign start
+- `player-facing-brief.md`: spoiler-light campaign intro
+- `gm-overview.md`: the high-level GM framing

--- a/00-campaign-frame/gm-overview.md
+++ b/00-campaign-frame/gm-overview.md
@@ -1,0 +1,34 @@
+# GM Overview
+
+## What This Is
+
+This note is the top-level GM interpretation of the campaign frame.
+
+## Running Principles
+
+- Treat Baldur's Gate as a machine made of institutions, districts, and personal loyalties.
+- Keep faction goals concrete and local before making them grand.
+- Let prosperity and exploitation exist side by side.
+- Use `content.md` notes as on-ramps, and deeper notes as zoomed-in tools.
+
+## Good Sources Of Conflict
+
+- overlapping jurisdictions
+- market competition
+- public safety failures
+- class resentment
+- post-war trauma
+- outside influence
+- criminal patronage masquerading as mutual aid
+
+## First Expansion Targets
+
+- district notes in `10-setting/locations/`
+- faction files in `20-factions/`
+- recurring NPCs in `30-people/`
+- active fronts in `40-adventures/`
+
+## Related Notes
+
+- `campaign-truths.md`
+- `starting-situation.md`

--- a/00-campaign-frame/player-facing-brief.md
+++ b/00-campaign-frame/player-facing-brief.md
@@ -1,0 +1,27 @@
+# Player-Facing Brief
+
+## What Players Need To Know
+
+Baldur's Gate stands ten years after a nearly apocalyptic crisis. The city survived, rebuilt, and became richer than ever, but the recovery came with costs. Foreign trade powers, guilds, political machines, and local strongmen all compete to shape daily life.
+
+## What The Campaign Feels Like
+
+Expect a city campaign with politics, factions, district-level loyalties, rumors, urban mysteries, and hard choices. Reputation, alliances, and local knowledge matter.
+
+## Useful Player Assumptions
+
+- The city is crowded, diverse, and tense.
+- Every neighborhood has its own rules and power brokers.
+- Official authority is real, but not always decisive.
+- Money opens doors, but so do favors and loyalties.
+
+## Questions Characters May Care About
+
+- Who really runs the district where we live or work?
+- Which factions can be trusted, and in what way?
+- What does rebuilding the city actually mean for ordinary people?
+
+## Related Notes
+
+- `premise.md`
+- `themes-and-tone.md`

--- a/00-campaign-frame/premise.md
+++ b/00-campaign-frame/premise.md
@@ -1,0 +1,19 @@
+# Premise
+
+## What This Is
+
+This campaign is set in Baldur's Gate in 1502 DR, ten years after the Absolute Crisis. The city survived invasion, psychic violation, infernal fallout, and political collapse, but it rebuilt itself by selling pieces of its sovereignty to foreign capital, empowered guilds, and ambitious factions.
+
+## Why It Matters In Play
+
+The campaign frame is not "save the city from ruin." The city is already alive, bustling, and profitable. The real question is what kind of city Baldur's Gate has become, who benefits from that new order, and what the characters are willing to protect, exploit, or tear down.
+
+## Core Tension
+
+Baldur's Gate is stronger than it was, richer than it was, and less unified than it was. Every district, faction, and institution now reflects that bargain.
+
+## Related Notes
+
+- `themes-and-tone.md`
+- `campaign-truths.md`
+- `starting-situation.md`

--- a/00-campaign-frame/starting-situation.md
+++ b/00-campaign-frame/starting-situation.md
@@ -1,0 +1,32 @@
+# Starting Situation
+
+## What This Is
+
+This note captures the default campaign start assumption for Baldur's Gate in 1502 DR.
+
+## Current State
+
+- The city is rebuilt enough to look powerful from the outside.
+- Political authority exists, but it is fragmented and transactional.
+- Foreign Kontors and local consortiums shape daily life through trade and influence.
+- The Flaming Fist still exists, but it is no longer the uncontested face of order.
+- The Outer City has developed distinct communities with their own interests.
+- Rumors, grudges, and unfinished business from the last decade remain active.
+
+## Starting Pressure Points
+
+- Competing definitions of public order
+- Economic exploitation hidden inside reconstruction
+- Distrust between old Baldurians, refugees, and new arrivals
+- Faction maneuvering around elections, contracts, charters, and district control
+- Strange consequences of the Githyanki presence and other post-crisis shifts
+
+## Default Opening Lens
+
+The characters begin in a city that works just well enough to conceal how unstable it really is.
+
+## Related Notes
+
+- `player-facing-brief.md`
+- `gm-overview.md`
+- `../10-setting/timeline.md`

--- a/00-campaign-frame/themes-and-tone.md
+++ b/00-campaign-frame/themes-and-tone.md
@@ -1,0 +1,32 @@
+# Themes and Tone
+
+## Primary Themes
+
+- Recovery after catastrophe
+- Prosperity bought at moral cost
+- Old power versus new power
+- Civic identity under pressure
+- Survival, compromise, and ambition
+
+## Tone
+
+The tone should feel grounded, urban, political, and a little dangerous. This is not a clean heroic frontier. It is a dense city full of deals, patronage, commerce, rumor, trauma, and competing visions of the future.
+
+## Good Story Modes
+
+- Street-level investigations
+- Faction politics
+- District-based intrigue
+- Moral bargains
+- Adventures where local consequences matter more than cosmic destiny
+
+## Avoid
+
+- Flattening the city into a simple good-versus-evil conflict
+- Treating every faction as secretly the same
+- Letting lore notes grow into long undifferentiated essays
+
+## Related Notes
+
+- `premise.md`
+- `gm-overview.md`

--- a/10-setting/baldurs-gate-overview.md
+++ b/10-setting/baldurs-gate-overview.md
@@ -1,0 +1,29 @@
+# Baldur's Gate Overview
+
+## What This Is
+
+A compact overview of Baldur's Gate in 1502 DR.
+
+## Current State
+
+Baldur's Gate is a rebuilt city marked by success and unease. It survived the Absolute Crisis and now stands as a thriving commercial center, but its reconstruction empowered foreign interests, merchant blocs, guild authorities, and criminal patronage networks.
+
+## What Defines The City Now
+
+- visible rebuilding alongside older scars
+- aggressive commercial growth
+- fragmented authority
+- intensified class division
+- expanding influence of the Outer City
+- permanent social paranoia after repeated crises
+
+## In One Sentence
+
+Baldur's Gate is a city that survived disaster by becoming wealthier, sharper, and more divided.
+
+## Related Notes
+
+- `timeline.md`
+- `politics/council-of-four-and-parliament.md`
+- `economy/sword-coast-hansa.md`
+- `locations/content.md`

--- a/10-setting/content.md
+++ b/10-setting/content.md
@@ -1,0 +1,22 @@
+# Setting Contents
+
+## What Lives Here
+
+This folder contains stable setting material: city overviews, timeline, institutions, economy, culture, and location indexes.
+
+## How To Use It
+
+Start with summary notes in this folder, then move into subfolders for specific domains. This is where long-form lore should be broken into reusable reference notes.
+
+## Main Subfolders
+
+- `politics/`
+- `law-and-order/`
+- `economy/`
+- `society-and-culture/`
+- `locations/`
+
+## Related Notes
+
+- `../00-campaign-frame/content.md`
+- `../20-factions/content.md`

--- a/10-setting/economy/content.md
+++ b/10-setting/economy/content.md
@@ -1,0 +1,17 @@
+# Economy Contents
+
+## What Lives Here
+
+This folder covers trade, reconstruction, prices, labor, guild monopolies, and the commercial systems that now define the city.
+
+## Why It Matters
+
+Economic power is political power in Baldur's Gate. These notes explain who profits, what daily life costs, and why the city's prosperity is unevenly shared.
+
+## Expected Notes
+
+- reconstruction and foreign investment
+- Kontors and consortiums
+- guild monopolies
+- labor and trade flows
+- prices, wages, and daily survival

--- a/10-setting/economy/price-of-life.md
+++ b/10-setting/economy/price-of-life.md
@@ -1,0 +1,30 @@
+# Price of Life
+
+## What This Is
+
+A campaign-use summary of what daily survival feels like in Baldur's Gate.
+
+## Key Takeaway
+
+The city contains extreme wealth and precarious poverty in close proximity. Costs, safety, and comfort vary sharply by district and status.
+
+## Practical Use At The Table
+
+Use this note to anchor:
+
+- lifestyle assumptions
+- what scarcity looks like
+- how expensive security and influence can be
+- which services are controlled by monopolies or special licenses
+
+## Expansion Targets
+
+- common wages by district
+- lodging benchmarks
+- black-market prices
+- faction-controlled services
+
+## Related Notes
+
+- `content.md`
+- `sword-coast-hansa.md`

--- a/10-setting/economy/sword-coast-hansa.md
+++ b/10-setting/economy/sword-coast-hansa.md
@@ -1,0 +1,27 @@
+# Sword Coast Hansa
+
+## What This Is
+
+A summary of Baldur's Gate's post-crisis economic rise.
+
+## Current State
+
+The city's recovery turned it into the center of a broad commercial network. This influence is not purely official or diplomatic; it grows through trade standardization, shipping, credit, contracts, and strategic geography.
+
+## Major Drivers
+
+- the Great Bargain and foreign reconstruction money
+- the rise of Kontors
+- consolidation into merchant consortiums
+- river and port traffic
+- guild-backed production and regulation
+
+## Core Tension
+
+Baldur's Gate became more important by giving outsiders new ways to shape its future.
+
+## Related Notes
+
+- `price-of-life.md`
+- `../../20-factions/amnian-kontor.md`
+- `../../20-factions/chionthar-consortium.md`

--- a/10-setting/law-and-order/content.md
+++ b/10-setting/law-and-order/content.md
@@ -1,0 +1,17 @@
+# Law and Order Contents
+
+## What Lives Here
+
+This folder covers how power is enforced on the ground: guards, wardens, private security, inspections, customs control, and overlapping jurisdictions.
+
+## Why It Matters
+
+In Baldur's Gate, justice is uneven. Who protects you, who can arrest you, and who gets away with violence depends heavily on district, status, and affiliation.
+
+## Expected Notes
+
+- city law enforcement
+- guild enforcement
+- private guards
+- customs and border control
+- prison, courts, and informal punishment

--- a/10-setting/law-and-order/flaming-fist-and-wardens.md
+++ b/10-setting/law-and-order/flaming-fist-and-wardens.md
@@ -1,0 +1,29 @@
+# Flaming Fist and Wardens
+
+## What This Is
+
+A summary of the fractured enforcement landscape in Baldur's Gate.
+
+## Flaming Fist
+
+The Flaming Fist still matters, but it no longer defines law and order for the whole city. It is strongest in elite zones, walls, customs points, and symbolic public authority.
+
+## Guild Wardens
+
+Guild Wardens enforce chartered rules inside economic life. They have practical authority because the guilds control trade, labor, and standards.
+
+## Other Enforcers
+
+- Kontor guards inside foreign enclaves
+- Ward bosses and Guild operators in poorer districts
+- private household and consortium security
+
+## Core Tension
+
+There is no single monopoly on force. Order is negotiated, purchased, delegated, and contested.
+
+## Related Notes
+
+- `content.md`
+- `../../20-factions/flaming-fist.md`
+- `../../20-factions/the-guild.md`

--- a/10-setting/locations/content.md
+++ b/10-setting/locations/content.md
@@ -1,0 +1,16 @@
+# Locations Contents
+
+## What Lives Here
+
+This folder organizes the city geographically. Each major region should have its own summary note and then narrower notes for districts, wards, landmarks, and points of interest.
+
+## How To Use It
+
+Start with the region `content.md`, then move downward into specific districts only when needed for play or prep.
+
+## Regions
+
+- `upper-city/`
+- `lower-city/`
+- `outer-city/`
+- `undercity/`

--- a/10-setting/locations/lower-city/content.md
+++ b/10-setting/locations/lower-city/content.md
@@ -1,0 +1,19 @@
+# Lower City Contents
+
+## What Lives Here
+
+This folder will contain the city's commercial engine: dense neighborhoods, guild influence, labor, docks, warehouses, reconstruction zones, and the places where most deals become real.
+
+## Initial Districts To Track
+
+- Brampton
+- Eastway
+- Heapside
+- The Steeps
+- Bloomridge
+- Seatower
+- Gray Harbour
+
+## Why It Matters
+
+If the Upper City governs prestige, the Lower City governs motion.

--- a/10-setting/locations/outer-city/content.md
+++ b/10-setting/locations/outer-city/content.md
@@ -1,0 +1,24 @@
+# Outer City Contents
+
+## What Lives Here
+
+This folder will contain the unwalled communities beyond the main city proper: refugee settlements, trade roads, satellite neighborhoods, and strange enclaves that now carry real political weight.
+
+## Initial Districts To Track
+
+- New Elturel
+- Rivington
+- Wyrm's Crossing
+- Twin Songs
+- Sow's Foot
+- Whitkeep
+- Norchapel
+- Little Calimshan
+- Stonyeyes
+- Blackgate
+- The K'liir
+- Tumbledown and the Floodway
+
+## Why It Matters
+
+The Outer City is no longer just spillover. It is part of the campaign's power map.

--- a/10-setting/locations/undercity/content.md
+++ b/10-setting/locations/undercity/content.md
@@ -1,0 +1,16 @@
+# Undercity Contents
+
+## What Lives Here
+
+This folder will contain sewers, tunnels, hidden spaces, criminal routes, forgotten foundations, and other sub-surface locations beneath or around the city.
+
+## Why It Matters
+
+The Undercity is where official maps become unreliable and informal power becomes easier to hide.
+
+## Expansion Targets
+
+- smuggling routes
+- hidden shrines
+- Guild access points
+- abandoned crisis scars

--- a/10-setting/locations/upper-city/content.md
+++ b/10-setting/locations/upper-city/content.md
@@ -1,0 +1,15 @@
+# Upper City Contents
+
+## What Lives Here
+
+This folder will contain the elite and ceremonial heart of the city: major patriar districts, high-status institutions, temples, and polished public spaces.
+
+## Initial Districts To Track
+
+- Manorborn
+- Temples District
+- The Wide
+
+## Expected Note Style
+
+Each district note should cover atmosphere, visible power, district rules, notable locations, key people, and immediate hooks.

--- a/10-setting/politics/content.md
+++ b/10-setting/politics/content.md
@@ -1,0 +1,17 @@
+# Politics Contents
+
+## What Lives Here
+
+This folder contains notes about formal government, legislative structures, elections, civic power, and the tension between hereditary authority and economic influence.
+
+## What Readers Should Expect
+
+These notes explain who can make decisions, how laws move, and which institutions are legitimate on paper versus powerful in practice.
+
+## Expected Notes
+
+- Council structures
+- Parliament procedures
+- elections and patronage
+- sovereignty disputes
+- public offices and civic rituals

--- a/10-setting/politics/council-of-four-and-parliament.md
+++ b/10-setting/politics/council-of-four-and-parliament.md
@@ -1,0 +1,29 @@
+# Council of Four and Parliament
+
+## What This Is
+
+A summary of Baldur's Gate's formal political structure in 1502 DR.
+
+## Council of Four
+
+The city still recognizes a four-seat executive structure, but the practical meaning of office has shifted. Political power is now tied more openly to economic leverage, tax contribution, and factional support.
+
+## Parliament of Peers
+
+The Parliament has become the main arena where old patriar power and new commercial power collide. Hereditary influence still matters, but coin now has a formal seat at the table.
+
+## Core Political Tension
+
+The city remains a republic in name and a plutocracy in practice.
+
+## Questions For Future Notes
+
+- Who currently occupies each major office?
+- Which blocs routinely vote together?
+- Where do popular pressure and Guild influence alter outcomes?
+
+## Related Notes
+
+- `content.md`
+- `../../20-factions/council-of-four.md`
+- `../../20-factions/parliament-of-peers.md`

--- a/10-setting/society-and-culture/content.md
+++ b/10-setting/society-and-culture/content.md
@@ -1,0 +1,17 @@
+# Society and Culture Contents
+
+## What Lives Here
+
+This folder contains social structure, demographics, faith, customs, trauma, prejudice, and how different communities live together or against one another.
+
+## Why It Matters
+
+Baldur's Gate is not just a political machine. It is a living city full of neighborhoods, identities, grief, pride, aspiration, and resentment.
+
+## Expected Notes
+
+- population and ancestry
+- refugees and integration
+- religion and public festivals
+- class and social rituals
+- shared myths and recent fears

--- a/10-setting/society-and-culture/melting-pot-on-the-sword-coast.md
+++ b/10-setting/society-and-culture/melting-pot-on-the-sword-coast.md
@@ -1,0 +1,25 @@
+# Melting Pot on the Sword Coast
+
+## What This Is
+
+A summary of Baldur's Gate as a diverse, crowded, and socially tense metropolis.
+
+## Current State
+
+Humans remain the majority, but the city contains a broad mix of ancestries, refugee populations, trade communities, and recent arrivals. Diversity is normal here, but harmony is not guaranteed.
+
+## Social Fault Lines
+
+- old citizens versus recent arrivals
+- wealthy districts versus working districts
+- native elites versus foreign blocs
+- refugees versus institutions that profit from their labor
+
+## Useful Campaign Angle
+
+Community identity should feel specific to district, trade, faith, and history, not just ancestry.
+
+## Related Notes
+
+- `content.md`
+- `../locations/content.md`

--- a/10-setting/timeline.md
+++ b/10-setting/timeline.md
@@ -1,0 +1,36 @@
+# Timeline
+
+## What This Is
+
+A short campaign-use timeline focused on the events most relevant to Baldur's Gate in 1502 DR.
+
+## Key Eras
+
+### Founding and Early Identity
+
+- c. 1068 DR: Balduran returns with wealth and fortifies Gray Harbour, laying the foundation for Baldur's Gate as a city rooted in trade and adventure.
+
+### Bhaalspawn Era
+
+- 1358 DR: The Time of Troubles reshapes divine and mortal history across Faerun.
+- 1368 DR: Sarevok's plot threatens war and economic collapse.
+- 1369 DR: Abdel Adrian survives the wider Bhaalspawn conflict and becomes central to the city's heroic memory.
+
+### Modern Crises
+
+- 1482 DR: Abdel Adrian dies, and Bhaal returns.
+- 1491 DR: Leadership fractures during the prelude to the next major crisis.
+- 1492 DR: The Absolute Crisis nearly destroys the city.
+- 1493 DR: The Great Bargain invites foreign powers into reconstruction.
+- 1496 DR: The K'liir takes root in the Outer City.
+- 1497 DR: Parliament is reformed to reflect economic power more directly.
+- 1502 DR: The present day. Baldur's Gate is thriving, unstable, and politically transformed.
+
+## How To Expand This Note
+
+If the timeline grows, split eras into separate files and keep this page as a summary index.
+
+## Related Notes
+
+- `baldurs-gate-overview.md`
+- `../20-factions/content.md`

--- a/20-factions/amnian-kontor.md
+++ b/20-factions/amnian-kontor.md
@@ -1,0 +1,13 @@
+# Amnian Kontor
+
+## Role In The City
+
+The Amnian Kontor is a foreign commercial enclave focused on finance, luxury trade, and influence through debt.
+
+## Current Position
+
+It represents one of the clearest examples of reconstruction money translating into long-term leverage over the city.
+
+## Why It Matters In Play
+
+Use this faction for banking pressure, contract politics, quiet sabotage, and elite commercial rivalry.

--- a/20-factions/chionthar-consortium.md
+++ b/20-factions/chionthar-consortium.md
@@ -1,0 +1,13 @@
+# Chionthar Consortium
+
+## Role In The City
+
+The Chionthar Consortium is a local merchant bloc built around river trade, shipping, storage, and Baldurian commercial interests.
+
+## Current Position
+
+It helps represent the city's attempt to answer foreign influence with organized local power.
+
+## Why It Matters In Play
+
+Use this faction for river traffic control, shipping disputes, local merchant politics, and anti-Kontor maneuvering.

--- a/20-factions/content.md
+++ b/20-factions/content.md
@@ -1,0 +1,19 @@
+# Factions Contents
+
+## What Lives Here
+
+This folder contains one file per faction, institution, or organized power bloc that meaningfully shapes the campaign.
+
+## How To Use It
+
+Each faction note should stay compact and gameable. It should explain what the faction wants, how it operates, where it is strongest, and how characters are likely to encounter it.
+
+## Recommended Faction Note Structure
+
+- role in the city
+- goals
+- resources
+- internal tensions
+- public face
+- hidden methods
+- adventure hooks

--- a/20-factions/council-of-four.md
+++ b/20-factions/council-of-four.md
@@ -1,0 +1,13 @@
+# Council of Four
+
+## Role In The City
+
+The Council of Four is the formal executive authority of Baldur's Gate.
+
+## Current Position
+
+It still carries symbolic and legal weight, but it operates in a city where economic power increasingly dictates political outcomes.
+
+## Why It Matters In Play
+
+The Council is useful whenever players deal with charters, emergency powers, public policy, major contracts, or attempts to legitimize broader faction goals.

--- a/20-factions/flaming-fist.md
+++ b/20-factions/flaming-fist.md
@@ -1,0 +1,13 @@
+# Flaming Fist
+
+## Role In The City
+
+The Flaming Fist is the city's best-known military and policing force.
+
+## Current Position
+
+Its authority is narrower than its reputation. It remains visible at walls, gates, customs points, and elite spaces, but it no longer fully defines order across the city.
+
+## Why It Matters In Play
+
+The Fist works well as an institution caught between duty, reputation, shrinking relevance, and political manipulation.

--- a/20-factions/harpers.md
+++ b/20-factions/harpers.md
@@ -1,0 +1,13 @@
+# Harpers
+
+## Role In The City
+
+The Harpers operate as an intelligence and influence network with an interest in balance, information, and resistance to dangerous concentrations of power.
+
+## Current Position
+
+In a city full of commercial competition and shadow politics, they have plenty to watch and plenty to oppose.
+
+## Why It Matters In Play
+
+Use the Harpers for quiet interventions, information trades, and morally complicated alliances.

--- a/20-factions/hellriders-of-new-elturel.md
+++ b/20-factions/hellriders-of-new-elturel.md
@@ -1,0 +1,13 @@
+# Hellriders of New Elturel
+
+## Role In The City
+
+The Hellriders of New Elturel represent refugee memory, piety, discipline, and a stubborn sense of civic identity transplanted into the Outer City.
+
+## Current Position
+
+They are shaped by trauma and displacement, but they are not passive. They organize, remember, and judge.
+
+## Why It Matters In Play
+
+Use this faction for refugee politics, faith-driven conflict, public service, and hard lines around duty and sacrifice.

--- a/20-factions/lantaner-concession.md
+++ b/20-factions/lantaner-concession.md
@@ -1,0 +1,13 @@
+# Lantaner Concession
+
+## Role In The City
+
+The Lantaner Concession is a compact but strategically important enclave tied to invention, smokepowder, and technical secrecy.
+
+## Current Position
+
+It has less territorial weight than other major trade powers, but its knowledge makes it disproportionately important.
+
+## Why It Matters In Play
+
+Use this faction for industrial espionage, strange devices, controlled technology, and unstable innovation.

--- a/20-factions/parliament-of-peers.md
+++ b/20-factions/parliament-of-peers.md
@@ -1,0 +1,13 @@
+# Parliament of Peers
+
+## Role In The City
+
+The Parliament is the main legislative battleground of Baldur's Gate.
+
+## Current Position
+
+It contains a built-in struggle between hereditary prestige and economic influence, making it a fertile site for lobbying, bribery, scandal, and bloc politics.
+
+## Why It Matters In Play
+
+Use this faction when laws, taxes, district policy, and civic legitimacy become part of the story.

--- a/20-factions/sembian-kontor.md
+++ b/20-factions/sembian-kontor.md
@@ -1,0 +1,13 @@
+# Sembian Kontor
+
+## Role In The City
+
+The Sembian Kontor specializes in logistics, contracts, bulk goods, and hard-nosed profit.
+
+## Current Position
+
+It is less interested in moral narratives than in reliable leverage over supply chains and hired force.
+
+## Why It Matters In Play
+
+Use this faction for mercenary contracts, shipping pressure, shortages, and ruthless commercial tactics.

--- a/20-factions/the-guild.md
+++ b/20-factions/the-guild.md
@@ -1,0 +1,13 @@
+# The Guild
+
+## Role In The City
+
+The Guild is a criminal, patronage, and information network that acts like an unofficial government in many working districts.
+
+## Current Position
+
+It thrives because it provides services, protection, and local order where formal institutions fail or do not care enough to intervene.
+
+## Why It Matters In Play
+
+The Guild should rarely feel like "just the thieves' guild." It is a political machine with a social base.

--- a/20-factions/unchained-kliir.md
+++ b/20-factions/unchained-kliir.md
@@ -1,0 +1,13 @@
+# The Unchained of the K'liir
+
+## Role In The City
+
+This faction is the Githyanki enclave that took root in the Outer City after the schism tied to Orpheus.
+
+## Current Position
+
+They are both outsiders and stakeholders, carrying alien practices into a city already struggling to define who belongs.
+
+## Why It Matters In Play
+
+Use this faction for cultural tension, military discipline, planar consequences, and uneasy local diplomacy.

--- a/20-factions/waterdhavian-kontor.md
+++ b/20-factions/waterdhavian-kontor.md
@@ -1,0 +1,13 @@
+# Waterdhavian Kontor
+
+## Role In The City
+
+The Waterdhavian Kontor channels northern trade, finished goods, magical commerce, and alliance interests into Baldur's Gate.
+
+## Current Position
+
+It is both a trade hub and a likely center of information gathering.
+
+## Why It Matters In Play
+
+Use this faction for diplomacy, espionage, magical procurement, and urban intrigue with a polished face.

--- a/20-factions/western-gate-trading-company.md
+++ b/20-factions/western-gate-trading-company.md
@@ -1,0 +1,13 @@
+# Western Gate Trading Company
+
+## Role In The City
+
+The Western Gate Trading Company is an overland trade and raw materials bloc with deep ties to patriar interests.
+
+## Current Position
+
+It sits where inherited power and commercial adaptation meet.
+
+## Why It Matters In Play
+
+Use this faction for caravan politics, resource competition, land routes, and conservative elite interests.

--- a/20-factions/worshipful-companies.md
+++ b/20-factions/worshipful-companies.md
@@ -1,0 +1,13 @@
+# Worshipful Companies
+
+## Role In The City
+
+The Worshipful Companies are Baldur's chartered guild powers. They regulate trades, protect monopolies, and exert political influence through wealth and organization.
+
+## Current Position
+
+They sit at the crossroads of labor, law, and commerce, making them some of the most durable institutions in the city.
+
+## Why It Matters In Play
+
+Use these factions when the story touches labor disputes, standards, contracts, inspections, or regulated access to goods and services.

--- a/20-factions/zhentarim.md
+++ b/20-factions/zhentarim.md
@@ -1,0 +1,13 @@
+# Zhentarim
+
+## Role In The City
+
+The Zhentarim represent a more openly predatory style of organized power than the Guild.
+
+## Current Position
+
+They compete for influence in spaces where fear, violence, and illicit opportunity create openings the city's legitimate institutions cannot close.
+
+## Why It Matters In Play
+
+Use this faction when you want sharper criminal pressure, mercenary calculation, or escalation beyond tolerated corruption.

--- a/30-people/allies/content.md
+++ b/30-people/allies/content.md
@@ -1,0 +1,5 @@
+# Allies Contents
+
+## What Lives Here
+
+This folder will contain recurring helpful NPCs, patrons, informants, and community contacts.

--- a/30-people/antagonists/content.md
+++ b/30-people/antagonists/content.md
@@ -1,0 +1,5 @@
+# Antagonists Contents
+
+## What Lives Here
+
+This folder will contain recurring rivals, hostile operators, corrupt officials, predatory fixers, and active threats with a face.

--- a/30-people/content.md
+++ b/30-people/content.md
@@ -1,0 +1,16 @@
+# People Contents
+
+## What Lives Here
+
+This folder stores notable NPCs once they matter enough to deserve dedicated pages.
+
+## How To Use It
+
+Do not create a person file just because a name appears once in lore. Add a note when the person is recurring, politically important, or likely to appear at the table.
+
+## Subfolders
+
+- `power-brokers/`
+- `allies/`
+- `antagonists/`
+- `rumor-npcs/`

--- a/30-people/power-brokers/content.md
+++ b/30-people/power-brokers/content.md
@@ -1,0 +1,5 @@
+# Power Brokers Contents
+
+## What Lives Here
+
+This folder will contain dukes, guild leaders, consortium heads, crime bosses, editors, priests, and anyone else whose choices can move districts or institutions.

--- a/30-people/rumor-npcs/content.md
+++ b/30-people/rumor-npcs/content.md
@@ -1,0 +1,5 @@
+# Rumor NPCs Contents
+
+## What Lives Here
+
+This folder will contain low-detail names and one-paragraph profiles for NPCs who are not yet important enough for a full note.

--- a/40-adventures/arcs/content.md
+++ b/40-adventures/arcs/content.md
@@ -1,0 +1,5 @@
+# Arcs Contents
+
+## What Lives Here
+
+This folder will contain medium- to long-term campaign arcs with clear stakes, phases, and likely faction involvement.

--- a/40-adventures/content.md
+++ b/40-adventures/content.md
@@ -1,0 +1,17 @@
+# Adventures Contents
+
+## What Lives Here
+
+This folder contains active campaign material: threats, arcs, hooks, and location-specific play prep.
+
+## How It Differs From Setting Notes
+
+Setting notes describe the world. Adventure notes describe what is happening now, who is moving, and what the characters can actually get involved in.
+
+## Subfolders
+
+- `arcs/`
+- `fronts-and-threats/`
+- `mysteries/`
+- `hooks-and-rumors/`
+- `locations-in-play/`

--- a/40-adventures/fronts-and-threats/content.md
+++ b/40-adventures/fronts-and-threats/content.md
@@ -1,0 +1,5 @@
+# Fronts and Threats Contents
+
+## What Lives Here
+
+This folder will contain moving pressures that advance over time whether or not the characters intervene.

--- a/40-adventures/hooks-and-rumors/content.md
+++ b/40-adventures/hooks-and-rumors/content.md
@@ -1,0 +1,5 @@
+# Hooks and Rumors Contents
+
+## What Lives Here
+
+This folder will contain short, reusable adventure seeds. Keep each note small enough to drop into a session quickly.

--- a/40-adventures/locations-in-play/content.md
+++ b/40-adventures/locations-in-play/content.md
@@ -1,0 +1,5 @@
+# Locations in Play Contents
+
+## What Lives Here
+
+This folder will contain temporary or active versions of locations that matter to current adventures, especially when they differ from stable lore notes.

--- a/40-adventures/mysteries/content.md
+++ b/40-adventures/mysteries/content.md
@@ -1,0 +1,5 @@
+# Mysteries Contents
+
+## What Lives Here
+
+This folder will contain investigations, hidden truths, rumor webs, and unresolved questions that can drive sessions.

--- a/50-sessions/content.md
+++ b/50-sessions/content.md
@@ -1,0 +1,12 @@
+# Sessions Contents
+
+## What Lives Here
+
+This folder stores the actual campaign record: session prep, recaps, unresolved threads, and consequences.
+
+## Suggested Pattern
+
+- one folder per session
+- one recap note per played session
+- one forward-looking prep note for the next session
+- update `recurring-threads.md` when new long-term consequences appear

--- a/50-sessions/recurring-threads.md
+++ b/50-sessions/recurring-threads.md
@@ -1,0 +1,9 @@
+# Recurring Threads
+
+## What This Is
+
+This note tracks unresolved consequences, faction shifts, promises, debts, enemies, and rumors that persist across sessions.
+
+## Current State
+
+No session history has been added yet.

--- a/60-player-handouts/city-guide.md
+++ b/60-player-handouts/city-guide.md
@@ -1,0 +1,9 @@
+# City Guide
+
+## What This Is
+
+This note will become a short guide players can read to understand Baldur's Gate at campaign start.
+
+## Current State
+
+Use `../00-campaign-frame/player-facing-brief.md` as the current source until a fuller guide is written.

--- a/60-player-handouts/content.md
+++ b/60-player-handouts/content.md
@@ -1,0 +1,16 @@
+# Player Handouts Contents
+
+## What Lives Here
+
+This folder contains documents intended to be shared directly with players.
+
+## Design Rule
+
+Keep these notes spoiler-light, readable on their own, and short enough to be useful before or between sessions.
+
+## Expected Notes
+
+- city guides
+- rumor sheets
+- public faction briefs
+- in-world letters and notices

--- a/60-player-handouts/faction-one-pagers.md
+++ b/60-player-handouts/faction-one-pagers.md
@@ -1,0 +1,9 @@
+# Faction One-Pagers
+
+## What This Is
+
+This note will eventually collect short, spoiler-light summaries of public-facing factions for player reference.
+
+## Current State
+
+No player-facing faction briefs have been added yet.

--- a/60-player-handouts/rumors.md
+++ b/60-player-handouts/rumors.md
@@ -1,0 +1,9 @@
+# Rumors
+
+## What This Is
+
+This note will hold short rumor bullets that can be handed to players, overheard in taverns, or seeded as downtime information.
+
+## Current State
+
+No rumor list has been added yet.

--- a/90-templates/content.md
+++ b/90-templates/content.md
@@ -1,0 +1,9 @@
+# Templates Contents
+
+## What Lives Here
+
+This folder contains templates and formatting rules for creating new notes consistently.
+
+## Why It Matters
+
+The fastest way for this repository to become hard to use is inconsistent note shape. These templates keep entries short, comparable, and easy to scan.

--- a/90-templates/faction-template.md
+++ b/90-templates/faction-template.md
@@ -1,0 +1,36 @@
+# Faction Template
+
+## Role In The City
+
+What this faction is and how the public understands it.
+
+## Goals
+
+- goal one
+- goal two
+
+## Resources
+
+- resource one
+- resource two
+
+## Internal Tensions
+
+What keeps the faction from acting as a monolith.
+
+## Public Face
+
+How ordinary people encounter the faction.
+
+## Hidden Methods
+
+What the faction does behind the scenes.
+
+## Hooks
+
+- hook one
+- hook two
+
+## Related Notes
+
+- related note

--- a/90-templates/location-template.md
+++ b/90-templates/location-template.md
@@ -1,0 +1,32 @@
+# Location Template
+
+## What This Is
+
+One-paragraph summary of the location.
+
+## Why It Matters In Play
+
+Why characters might visit, care about, or become entangled here.
+
+## Atmosphere
+
+What the location feels like at first glance.
+
+## Power and Control
+
+Who actually controls the space.
+
+## Notable Features
+
+- feature one
+- feature two
+- feature three
+
+## Hooks
+
+- hook one
+- hook two
+
+## Related Notes
+
+- related note

--- a/90-templates/npc-template.md
+++ b/90-templates/npc-template.md
@@ -1,0 +1,32 @@
+# NPC Template
+
+## Role
+
+Who this person is in one sentence.
+
+## What They Want
+
+- short-term goal
+- long-term goal
+
+## Public Face
+
+How they present themselves.
+
+## Leverage
+
+What they can offer, threaten, or control.
+
+## Relationships
+
+- ally
+- rival
+- obligation
+
+## Use In Play
+
+How this NPC is most likely to appear at the table.
+
+## Related Notes
+
+- related note

--- a/90-templates/session-template.md
+++ b/90-templates/session-template.md
@@ -1,0 +1,35 @@
+# Session Template
+
+## Summary
+
+One-paragraph overview of the session or prep target.
+
+## Scenes To Expect
+
+- scene one
+- scene two
+
+## Active Factions
+
+- faction one
+- faction two
+
+## Important NPCs
+
+- npc one
+- npc two
+
+## Clues and Revelations
+
+- clue one
+- clue two
+
+## Consequences
+
+- immediate consequence
+- long-term consequence
+
+## Follow-Up
+
+- next prep task
+- note to update

--- a/90-templates/style-guide.md
+++ b/90-templates/style-guide.md
@@ -1,0 +1,40 @@
+# Style Guide
+
+## Core Rules
+
+- Use one topic per file.
+- Add a `content.md` file to every folder.
+- Prefer short summaries over long essays.
+- Put the most useful information near the top.
+- Use links to connect related notes instead of duplicating large sections.
+
+## File Naming
+
+- use lowercase
+- use hyphens instead of spaces
+- keep names descriptive and short
+
+## Summary Note Rules
+
+A `content.md` file should answer three questions:
+
+1. What lives in this folder?
+2. When should someone read this folder?
+3. What child notes or subfolders matter most?
+
+## Detail Note Rules
+
+Most lore notes should include:
+
+- what this is
+- why it matters in play
+- current state
+- key tensions
+- related notes
+
+## Splitting Rule
+
+If a note grows beyond a quick read, split it into:
+
+- a shorter parent summary
+- multiple child notes for the details

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Cities and Schemes
+
+This repository is a markdown knowledge base for a Dungeons and Dragons campaign centered on Baldur's Gate in 1502 DR.
+
+The structure is designed for layered reading:
+
+- Start with `content.md` in any folder for a quick summary.
+- Open a focused note when you need more detail.
+- Keep stable lore separate from active campaign play materials.
+
+If a folder grows too large, add a `content.md` summary first and split the material into smaller notes beneath it.

--- a/content.md
+++ b/content.md
@@ -1,0 +1,23 @@
+# Repository Contents
+
+## What This Repository Is
+
+This repository stores campaign lore, game prep, session history, and player-facing handouts for a Dungeons and Dragons campaign set in and around Baldur's Gate.
+
+## How To Read It
+
+- `00-campaign-frame/` explains what the campaign is about.
+- `10-setting/` holds stable world knowledge.
+- `20-factions/` tracks institutions and power blocs.
+- `30-people/` stores notable NPCs.
+- `40-adventures/` contains active plots and playable material.
+- `50-sessions/` records what happened at the table.
+- `60-player-handouts/` contains shareable documents.
+- `90-templates/` defines the formatting standard for future notes.
+
+## Design Rules
+
+- Every folder has a `content.md` file that explains what lives there.
+- Overview notes should be short and useful on their own.
+- Detailed notes should link back to broader summaries.
+- Session material should not rewrite stable setting lore unless the world has actually changed in play.


### PR DESCRIPTION
This PR scaffolds the campaign markdown knowledge base for Baldur's Gate in 1502 DR.

Summary:
- add a layered campaign wiki structure for frame, setting, factions, people, adventures, sessions, handouts, and templates
- add `content.md` summary files at every folder layer for quick context without loading full subtrees
- seed the first top-level campaign, setting, and faction notes from the current dossier
- add style and note templates to keep future entries consistent

Verification:
- confirmed every directory currently in the repo contains a `content.md`