### PR TITLE
Add secret faction dossier notes

### DIFF
--- a/20-factions/conspiracists/content.md
+++ b/20-factions/conspiracists/content.md
@@ -1,0 +1,16 @@
+# Conspiracists Contents
+
+## What Lives Here
+
+This folder holds the truth-seeking cells that believe Baldur's Gate was never rebuilt honestly. Each note covers one conspiracy leader, their inner circle, and the hidden narrative they sell to the desperate, paranoid, or traumatized.
+
+## Why It Matters
+
+These groups operate quietly but can trigger riots, infiltrate the press, and drag the city into paranoia. They have hooks into public grief, refugee trauma, and institutional distrust.
+
+## Expected Notes
+
+- `the-seeker-of-the-hidden-sky.md`
+- `the-damnation-seeker.md`
+- `the-cogwork-quack.md`
+- `the-memetic-purist.md`

--- a/20-factions/conspiracists/the-cogwork-quack.md
+++ b/20-factions/conspiracists/the-cogwork-quack.md
@@ -1,0 +1,19 @@
+# The Cogwork Quack
+
+## Role In The City
+
+Glim-Glim and the Purified believe the Lantaner Concession is dosing the populace with clockwork organisms to control emotions. They target the waterworks and the Lantan technologists with sabotage.
+
+## Current Position
+
+The Purified live off rainwater, disrupt pumps, and attempt to expose the "nano-cogs" they believe circulate through the city. Their paranoia extends to the Alchemists' Company and Gond's clergy, who they suspect of supplying binders for the devices.
+
+## Why It Matters In Play
+
+They can force a crisis around infrastructure, pushing PCs into covert operations to defend water supply or dismantle a pump station rigged with their detectors while the cult frames it as a plot by the Lantaners.
+
+## Hooks
+
+- The Purified need help building a working detector so they can prove the cogs exist.
+- Sabotaging a pump might earn the PCs a visit from Flaming Fist investigators and a standoff with the Concessions' engineers.
+- Their exile might be ending if they find undeniable proof, and they will use anyone who can turn that proof into spectacle.

--- a/20-factions/conspiracists/the-damnation-seeker.md
+++ b/20-factions/conspiracists/the-damnation-seeker.md
@@ -1,0 +1,19 @@
+# The Damnation-Seeker
+
+## Role In The City
+
+Lord Perrine Hhune leads the Elturel Remembrance Society, a conspiracy group convinced that Baldur's Gate is built on infernal blood money and that the righteous city must be purged before it sinks into Hell.
+
+## Current Position
+
+The Society dresses as an aid group but funnels refugees into investigations of the Patriar families and Consortiums. They test goods for soul signatures, saboteurs shipments they deem damned, and spread rumors that the Hellriders traded their honor for infernal deals.
+
+## Why It Matters In Play
+
+They can trigger a moral crisis around wealth, divine deals, and refugee treatment—especially when a player is forced to choose between comforting refugees or exposing a scandal that might be built on fear rather than fact.
+
+## Hooks
+
+- Perrine wants proof of soul-forged contracts or a ledger he can burn to break the "deal."
+- The cult will use a player’s kindness toward newcomers as leverage to sow distrust in the Upper City.
+- The Hellriders or any patriar who shelters refugees attract their violent attention.

--- a/20-factions/conspiracists/the-memetic-purist.md
+++ b/20-factions/conspiracists/the-memetic-purist.md
@@ -1,0 +1,19 @@
+# The Memetic Purist
+
+## Role In The City
+
+Calliope and the Society of Baldurian Integrity wage a culture war, claiming foreign architecture, art, and stories are memetic weapons intended to erase Baldur's Gate.
+
+## Current Position
+
+They vandalize Waterdhavian spectacles, disrupt performances at the Circus of the Last Days, and use paladin-inspired rituals to brand foreign art as psychic toxins. They point at Harpers and the Circus as the sources of the assault.
+
+## Why It Matters In Play
+
+This group is perfect for escalating pride versus paranoia, forcing players to defend or discredit the purity narrative while dealing with angry crowds and vandalism.
+
+## Hooks
+
+- Calliope wants to recruit the PCs to expose a supposedly memetic Waterdhavian show.
+- A plan to paint a banned mural or sabotage a performance could have diplomatic fallout.
+- Their attention on the Circus might draw planar energy that attracts other factions.

--- a/20-factions/conspiracists/the-seeker-of-the-hidden-sky.md
+++ b/20-factions/conspiracists/the-seeker-of-the-hidden-sky.md
@@ -1,0 +1,19 @@
+# The Seeker of the Hidden Sky
+
+## Role In The City
+
+Xylia and her network, The Unveiled, are a conspiracy cell convinced that the Absolute Crisis was staged to justify foreign control. They operate through whisper campaigns, vandalized propaganda, and infiltrated presses.
+
+## Current Position
+
+They quietly mark buildings, intercept *Baldur's Mouth* dispatches, and shadow key officials to prove publicly unimaginable accusations about doppelgangers, shapeshifters, and staged crises. The K'liir are viewed as enforcers of their imagined plot, and they single out the Sorcerous Sodality and the Harpers as collaborators.
+
+## Why It Matters In Play
+
+The Unveiled can rally paranoid districts, cause panic, or create evidence that drags institutions into overreaction. Their greatest strength is forcing authorities to defend themselves against accusations of treason while Xylia keeps expanding her myth.
+
+## Hooks
+
+- Xylia wants documents or artifacts that "prove" the cabal's past replacements.
+- The Unveiled will target a player who works for a faction they already suspect of being a shapeshifter.
+- Anything tied to the Harpers or Githyanki can trigger a propaganda campaign that destabilizes elections.

--- a/20-factions/content.md
+++ b/20-factions/content.md
@@ -17,3 +17,8 @@ Each faction note should stay compact and gameable. It should explain what the f
 - public face
 - hidden methods
 - adventure hooks
+
+## Subfolders
+
+- `conspiracists/` for the conspiracy cells targeting politics and rumor
+- `cults/` for apocalyptic and occult sects that stir crisis through faith, magic, or finance

--- a/20-factions/cults/content.md
+++ b/20-factions/cults/content.md
@@ -1,0 +1,17 @@
+# Cults Contents
+
+## What Lives Here
+
+This folder catalogs fanatic sects that use faith, magic, or economic doctrine to pursue apocalyptic ends. Each file distills their manifesto, membership, and preferred methods.
+
+## Why It Matters
+
+These cults can provoke assassinations, ritual violence, and planar disruptions that destabilize districts on short notice. They are dangerous because they combine ideology with a ready arsenal of loyal devotees.
+
+## Expected Notes
+
+- `the-gilded-vein.md`
+- `the-plague-of-remembrance.md`
+- `the-hands-of-the-absolute.md`
+- `the-carnival-of-whispers.md`
+- `the-takers-of-the-tithe.md`

--- a/20-factions/cults/the-carnival-of-whispers.md
+++ b/20-factions/cults/the-carnival-of-whispers.md
@@ -1,0 +1,19 @@
+# The Carnival of Whispers
+
+## Role In The City
+
+This fey-pact cult hides inside the Circus of the Last Days and feeds on emotion, aiming to anchor the circus permanently so the city remains in a waking dream.
+
+## Current Position
+
+They disguise cultists as performers, steal intense feelings from crowds, and work to expand the circus's planar tether, drawing the Harpers and Sorcerous Sodality's attention.
+
+## Why It Matters In Play
+
+They can unman citizens with emotional manipulation, cause a festival to turn into a nightmare, or compel players to stop a performance that literally rewrites reality.
+
+## Hooks
+
+- Mister Smiles wants the PCs to stage a performance that generates a specific emotion he can siphon.
+- The circus’s planar anchor is weakening; if the PCs help, the city might become a permanent dream.
+- Harpers might ask the players to investigate strange disappearances tied to the circus.

--- a/20-factions/cults/the-gilded-vein.md
+++ b/20-factions/cults/the-gilded-vein.md
@@ -1,0 +1,19 @@
+# The Gilded Vein
+
+## Role In The City
+
+Valerius Thorne's cult of economic assassins believes the Sword Coast's markets are too emotional and vows to cleanse commerce through calculated chaos.
+
+## Current Position
+
+They operate from shadows within banking districts, killing consortium heads, forging cursed coin, and blackmailing Kontor directors to destabilize the flow of capital until the city begs for their ordered system.
+
+## Why It Matters In Play
+
+They can provoke a financial crash, hold exchange rates hostage, or target a guild player, which drags the PCs into a race against assassins and manipulable markets.
+
+## Hooks
+
+- The cult needs a player with banking knowledge to bypass a cursed ledger.
+- The Vein will target an ally of the Amnian Kontor to send a message about "pure" markets.
+- Stopping a ritual assassination could expose their insecurity about a bad debt they fear the PCs will uncover.

--- a/20-factions/cults/the-hands-of-the-absolute.md
+++ b/20-factions/cults/the-hands-of-the-absolute.md
@@ -1,0 +1,19 @@
+# The Hands of the Absolute
+
+## Role In The City
+
+This remnant of the Absolute cult seeks to reassemble the Netherbrain by raising a psychic host, turning neighborhoods into resonance chambers.
+
+## Current Position
+
+They kidnap vulnerable psions, build attunement chambers beneath the city, and quietly recruit the mentally scarred, while the K'liir and Gravekeepers are drawn into the hunt for the echoing ritual energies.
+
+## Why It Matters In Play
+
+Their experiments can threaten a district with psychic echoes, unclean slaughter, or planar breaches, forcing players to decide how to silence or recruit their captives.
+
+## Hooks
+
+- The cult kidnaps a clerk with latent psychic talent, prompting a rescue mission.
+- A resonance chamber leaks energy that starts a mass vision, threatening public panic.
+- Players can choose to trap the Voice or let them recruit a new host for a desperate plan.

--- a/20-factions/cults/the-plague-of-remembrance.md
+++ b/20-factions/cults/the-plague-of-remembrance.md
@@ -1,0 +1,19 @@
+# The Plague of Remembrance
+
+## Role In The City
+
+Lady Emmeline Vhage leads a patriotic death cult that blames refugees for the city's pain and secretly orchestrates atrocities to spark civil war.
+
+## Current Position
+
+Members dress as Hellriders or refugees, commit murders in refugee camps, spread stories about divine poison, and pressure the Peerage of Blood into cleansing the city by force.
+
+## Why It Matters In Play
+
+They threaten any attempt to bridge Baldurians and refugees, and their actions can force the PCs to defend camps, expose false-flag murders, or confront fanatical patriars.
+
+## Hooks
+
+- The cult plants evidence implicating New Elturel refugees in a massacre.
+- PCs trusted by refugees might be targeted for retribution that also touches the Flaming Fist.
+- Stopping their rituals halves the civic tension but may reveal Lady Vhage's noble allies.

--- a/20-factions/cults/the-takers-of-the-tithe.md
+++ b/20-factions/cults/the-takers-of-the-tithe.md
@@ -1,0 +1,19 @@
+# The Takers of the Tithe
+
+## Role In The City
+
+This Myrkul-worshipping cult stalks the city's most gifted individuals, killing them to collect perfect souls for their god's resurrection.
+
+## Current Position
+
+They work in hunting trios, using soul-trapping weapons, targeting masters of guilds, Sorcerous Sodality talents, and famous adventurers, while keeping everything anonymous behind skeletal messengers.
+
+## Why It Matters In Play
+
+Any player or NPC with renown is potential prey, and each assassination becomes a public event that rattles every powerful faction, forcing the PCs to guard, investigate, or retaliate.
+
+## Hooks
+
+- They offer to spare a hero in exchange for a bargain with uncomfortably necromantic terms.
+- A mage's missing soul gem leads the PCs to a hidden ritual chamber beneath the city.
+- Their pattern of kills highlights a single guild, forcing the leadership to either fight them openly or pay protection.


### PR DESCRIPTION
This PR adds a nested secret-faction layer on top of the campaign knowledge-base scaffold.

Summary:
- add `20-factions/conspiracists/` and `20-factions/cults/` with `content.md` summaries
- convert the faction dossier into concise, gameable notes for each secret faction
- update `20-factions/content.md` so the new clandestine layers are discoverable

Notes:
- this PR is stacked on top of #1 and is intended to merge after the scaffold structure is in place
- faction theories are presented as rumors or beliefs rather than verified truths