### PR TITLE
Deepen batch-5 factions with associations and management-board pages

### DIFF
--- a/20-Factions/baldurs-mouth/README.md
+++ b/20-Factions/baldurs-mouth/README.md
@@ -5,4 +5,5 @@ The city's broadsheet, edited by Ettvard Needle; for-hire front-page coverage.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
-- [people/](people/) — Named figures: ettvard-needle.
+- [people/](people/) — Named figures: ettvard-needle, the-interim-management-board.
+- [associations/](associations/) — Items, holdings, vehicles (credential-of-balduran, heapside-print-shop).

--- a/20-Factions/baldurs-mouth/associations/README.md
+++ b/20-Factions/baldurs-mouth/associations/README.md
@@ -1,0 +1,8 @@
+# Baldur's Mouth — associations
+
+Items, holdings, and vehicles the faction guards.
+
+## Index
+
+- [credential-of-balduran.md](credential-of-balduran.md)
+- [heapside-print-shop.md](heapside-print-shop.md)

--- a/20-Factions/baldurs-mouth/associations/credential-of-balduran.md
+++ b/20-Factions/baldurs-mouth/associations/credential-of-balduran.md
@@ -1,0 +1,37 @@
+---
+name: credential-of-balduran
+description: The Baldur's Mouth's official press signet — a "golden ticket" that forces high-level NPCs to grant audience to its bearer. Currently held by Kaelan.
+---
+
+# The Credential of Balduran
+
+A heavy signet ring stamped with the Mouth's masthead and the city's foundational seal — issued by [Ettvard Needle](../people/ettvard-needle.md) to a small number of trusted stringers. Per `dm-notes`, it is *"a golden ticket forcing high-level NPCs to interact with the bearer."* Kaelan (PC) holds one; whether others were issued, and to whom, is not on the page.
+
+## What the Credential does
+
+- **Forced audience.** Patriars, Kontor consuls, Worshipful Company masters, Council aides — almost any city actor of rank — must grant the bearer at least a brief interview, by long-standing convention. Refusing is itself news, and they know it.
+- **Cover.** Anywhere a bearer needs to be (a Counting House foyer, a Watch checkpoint, the press benches at Parliament, an Upper City salon) the Credential is the cover story. Stringers travel with one.
+- **Liability.** The Credential identifies the bearer as a Mouth asset. After the [Western Gate](../../western-gate-trading-company/summary.md) "press blackout" and Needle's kidnapping (see [Ettvard Needle](../people/ettvard-needle.md)), bearers are now also marked for the **Interim Management Board** and the Sembian mercenaries enforcing the new editorial line.
+
+## Who holds one (known)
+
+- **Kaelan** — issued during *The Siege Edition* arc. Used to deliver the **Consortium insurance-fraud investigation**. Per `dm-notes`, Needle treats the holders as a "suicide squad of journalists" sent into dangerous places to fetch stories he then sells to both the public and his secret patrons.
+- The dossier does not enumerate other holders by name; assume one or two are out there from the pre-week-7 era.
+
+## After Needle
+
+- The Interim Management Board has not formally **revoked** outstanding Credentials (doing so publicly would confirm the kidnapping). Instead, the Board is quietly canceling appointments and routing the bearers' submissions into the round-file.
+- A Credential bearer who walks into the print shop today is in real danger — both from the Board and from the [Cult of the Returning Lord](../../cult-of-the-returning-lord/summary.md) cell that took Needle.
+
+## Hooks
+
+- Use the Credential to force an audience the party would otherwise never get — Lyra Silvershield, Consul Athar, Master Helma Tallowshand. Each use is logged somewhere.
+- Use it to bluff into the print shop's archives ahead of the Board's full lockdown, and pull Needle's source files on insurance fraud.
+- Surrender or destroy the Credential to break the Mouth's last claim on the bearer.
+
+## See also
+
+- [Baldur's Mouth](../summary.md); [Ettvard Needle](../people/ettvard-needle.md).
+- [Heapside print shop](heapside-print-shop.md) — where the Credentials are issued.
+- [Party](../../party/summary.md) — Kaelan is the canonical holder.
+- Source: `dm-notes.docx`; `baldurs-mouth.docx`.

--- a/20-Factions/baldurs-mouth/associations/heapside-print-shop.md
+++ b/20-Factions/baldurs-mouth/associations/heapside-print-shop.md
@@ -1,0 +1,40 @@
+---
+name: heapside-print-shop
+description: The Baldur's Mouth's single chaotic print shop in Heapside — physically a small operation, politically the city's loudest amplifier.
+---
+
+# The Heapside Print Shop
+
+The [Baldur's Mouth](../summary.md)'s only physical seat: a single chaotic print shop in **Heapside** (Lower City), per the dossier and `dm-notes`. Small footprint, outsized reach. The Credential of Balduran (see [credential-of-balduran.md](credential-of-balduran.md)) is issued from here; the [Harpers](../../harpers/summary.md) drop their leaks here; the **Interim Management Board** moved in here after the Western Gate "press blackout."
+
+## What's inside
+
+- **Two presses** (one main, one for leaflets and ad inserts), heavy iron, fed by hand.
+- **A wall of woodcut blocks** — staged sketches for the *Siege Edition*, the *Githyanki Garrison* plate, the spoiled-meat plates Goodman Borlu paid to kill (cross-reference [Worshipful Company of Butchers & Tanners](../../wc-butchers-tanners/summary.md)).
+- **A morgue of stringer notes** — Kaelan's insurance-fraud working files, source statements for the Consortium hit piece, an unprinted manuscript of Mad' Meggan's cultist-captive bombshell that Needle wouldn't run "without verifiable proof."
+- **Needle's office,** kept locked. Includes the off-the-books ledger of who paid for which front page (the *patron book*), and his draft of the next *Obulus*.
+
+## Who's there now
+
+- The **Interim Management Board** — pro-Consortium replacements installed by the [Western Gate Trading Company](../../western-gate-trading-company/summary.md) after Needle's kidnapping. Editorial line: pure propaganda for Archduke **Lyra Silvershield**, the Consortiums, and the [Peerage of Coin](../../peerage-of-coin/summary.md).
+- A small detachment of **Sembian mercenaries** at the door, ostensibly "protecting against agitators." Effectively a checkpoint.
+- The original press staff — sketch-artists, stringers, woodcut engravers — under the Board's editorial control. Loyalty mixed.
+- The **Whispering Stones presence**: per `dm-notes`, alien whispers (likely tied to the [Hands of the Absolute](../../hands-of-the-absolute/summary.md) or Far Realm remnants) appear to be subconsciously shaping the Mouth's narrative through the presses themselves.
+
+## Vulnerabilities
+
+- The **patron book** in Needle's locked office names every faction that paid for a front page — Western Gate, Butchers, the [Patriar Heritage Society](../../patriar-heritage-society/summary.md), the [Plague of Remembrance](../../plague-of-remembrance/summary.md), and others. Single most valuable document in the building.
+- The **morgue** holds the working files for the unaltered insurance-fraud investigation. Under the new Board, those files will be destroyed; recovering them salvages the original story.
+- **Plate-altering attacks** by the [Unveiled](../../unveiled/summary.md) have already proven the door isn't actually secure.
+
+## Hooks
+
+- Hostile takeover (debated by the party in `dm-notes` week 6) — seize the press for a single edition. Costly. Loud.
+- Quiet break-in for the patron book and morgue files; let the Board keep printing while the party publishes the source material elsewhere (the [Bibliophile](../../bibliophile/summary.md) buys; the [Harpers](../../harpers/summary.md) leak).
+- Sabotage the next edition by altering plates — the Unveiled's playbook, but for the party's purposes.
+
+## See also
+
+- [Baldur's Mouth](../summary.md); [Ettvard Needle](../people/ettvard-needle.md).
+- [Credential of Balduran](credential-of-balduran.md) — issued from here.
+- Source: `dm-notes.docx`; `baldurs-mouth.docx`; `dossier-baldurs-gate-…` Part V Ch.12.

--- a/20-Factions/baldurs-mouth/people/README.md
+++ b/20-Factions/baldurs-mouth/people/README.md
@@ -5,3 +5,4 @@ Named figures.
 ## Index
 
 - [ettvard-needle.md](ettvard-needle.md)
+- [the-interim-management-board.md](the-interim-management-board.md)

--- a/20-Factions/baldurs-mouth/people/the-interim-management-board.md
+++ b/20-Factions/baldurs-mouth/people/the-interim-management-board.md
@@ -1,0 +1,47 @@
+---
+name: the-interim-management-board
+description: The pro-Consortium replacement editorship installed at the Baldur's Mouth after Ettvard Needle's kidnapping; mouthpiece for Silvershield and the Coin.
+---
+
+# The Interim Management Board
+
+The replacement editorship installed at the [Baldur's Mouth](../summary.md) after [Ettvard Needle](ettvard-needle.md) was kidnapped (per `dm-notes` and the week-7 issue itself). No individual editor is named on the masthead — only **"the Interim Management Board"** — which is itself the message: editorial responsibility has been depersonalized so no one can be embarrassed by tomorrow's reversal.
+
+## Who is actually behind it
+
+- **[Western Gate Trading Company](../../western-gate-trading-company/summary.md)** — primary movers; their muscle removed Needle and their money is funding the Board.
+- **[Chionthar Consortium](../../chionthar-consortium/summary.md)** — Factor Errinthal's faction, the direct beneficiary of the insurance-fraud cover-up.
+- **[Peerage of Coin](../../peerage-of-coin/summary.md)** & the **[Council of Four](../../council-of-four/summary.md)** under Archduke **Lyra Silvershield** — the political cover.
+
+The Board's stated ownership is opaque. The week-7 editorial frames it as a civic-minded restructuring after Needle "officially vacated his position (and likely the city, fleeing the righteous consequences of his libel)."
+
+## Editorial line
+
+Per the week-7 issue:
+
+- **Retraction-first.** The first business of the new Mouth is *retracting* the Consortium insurance-fraud story as "categorically false" malicious fabrication.
+- **Glorify the Archduke.** Page-one praise for Silvershield's "Strategic Reserve Reallocation" (i.e., confiscation of Outer City food stores) and night-raid against the Free Trader barricades.
+- **Justify privatization.** Endorse the Sembian mercenary deployment, the Counting House fortification, and the "temporary cessation of unvetted, independent printing" — i.e., lock the city's other presses.
+- **Demonize the opposition.** Reframe the [Plague of Remembrance](../../plague-of-remembrance/summary.md) breadline massacre as a frame-up, the [Unveiled](../../unveiled/summary.md) as criminals, the [Free Traders](../../free-traders-of-the-outskirts/summary.md) as hoarders, and the [Peerage of Blood](../../peerage-of-blood/summary.md) as obstructionists.
+
+## Tone
+
+Sycophantic where Needle was lurid. Bureaucratic euphemism where Needle was direct. Where Needle ended each issue with the *Obulus* (his "Thought for the Week"), the Board ends with **advertising**.
+
+## Vulnerabilities
+
+- The Board is **not an editor**, and it shows. Its by-lines are inconsistent, its facts are checkable against Kaelan's surviving morgue (see [Heapside print shop](../associations/heapside-print-shop.md)), and the original presses' stringers know exactly what is being suppressed.
+- The Board cannot **publicly revoke** outstanding Credentials of Balduran without confirming Needle's removal was hostile (see [credential-of-balduran.md](../associations/credential-of-balduran.md)).
+- The week-7 lockdown of "unvetted independent printing" is unenforced in the Outer City; pamphlets there directly contradict the front page.
+
+## Hooks
+
+- Out the Board: prove it is funded by the Consortium and run by the Western Gate, and its credibility evaporates overnight.
+- Negotiate with the Board for a paid placement of the party's choice — the price is exposure to the same patrons the Board now answers to.
+- Disrupt the press long enough for the original stringers to publish the morgue files unaltered.
+
+## See also
+
+- [Baldur's Mouth](../summary.md); [Ettvard Needle](ettvard-needle.md).
+- [Heapside print shop](../associations/heapside-print-shop.md).
+- Source: `baldurs-mouth.docx` (week 7 editorial); `dm-notes.docx`.

--- a/20-Factions/high-moon-coster/README.md
+++ b/20-Factions/high-moon-coster/README.md
@@ -6,3 +6,4 @@ Remnant coster led by the Oberon family; bankrolling adventurers in hopes of res
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: oberon-family.
+- [associations/](associations/) — Items, holdings, vehicles (cloakwood-expedition).

--- a/20-Factions/high-moon-coster/associations/README.md
+++ b/20-Factions/high-moon-coster/associations/README.md
@@ -1,0 +1,7 @@
+# High Moon Coster — associations
+
+Items, holdings, and vehicles the faction guards.
+
+## Index
+
+- [cloakwood-expedition.md](cloakwood-expedition.md)

--- a/20-Factions/high-moon-coster/associations/cloakwood-expedition.md
+++ b/20-Factions/high-moon-coster/associations/cloakwood-expedition.md
@@ -1,0 +1,32 @@
+---
+name: cloakwood-expedition
+description: The High Moon Coster's currently-running adventuring sponsorship into a rumored Cloakwood ruin; the bet meant to refloat the Oberon manor.
+---
+
+# The Cloakwood Expedition
+
+The current **active bet** of the [High Moon Coster](../summary.md): a sponsored adventuring party sent into a rumored ruin in the **Cloakwood**, hoping to recover a rare artifact that would restore a sliver of the [Oberon family](../people/oberon-family.md)'s lost fortune. The single largest commitment the family has made in years.
+
+## Terms (per `faction-quests.xlsx`)
+
+- **Small purse up front**, scraped together from manor heirlooms and a quiet line of credit.
+- **Percent of recovered artifacts**, with the Oberon name attached to whatever comes back — the family wants the find publicly associated with the High Moon brand as much as it wants the gold.
+- **Covenant of exclusivity**: the party works the Cloakwood for the Oberons until the ruin is cleared, with a kill-fee if they break it.
+
+## Where the bet sits
+
+- The party is in the field. No retrieval, no failure, no contact has come back as of the most recent dispatches.
+- The Oberons' parallel attempt to retain the city's newest celebrity adventurers (likely the [PCs](../../party/summary.md)) at the **Blushing Mermaid** was rebuffed — *"the party's newfound (and mysterious) wealth is becoming common knowledge"* per `dm-notes`. The Oberons are reading this as needing to scout less-courted parties next time.
+- Cousins are hunting for a richer second purse, or a co-sponsor (most likely the [Jhasso family](../../seven-suns/people/jhasso-family.md), with whom the Oberons sometimes pool contacts).
+
+## Hooks
+
+- The party crosses paths with the **Oberon-sponsored fledgling party** in the Cloakwood — as rivals for the same find, or as casualties whose contract now needs an executor.
+- A second, sweeter approach from the Oberons: a specific Cloakwood site, a Jhasso heirloom recovery cut in for the percent. The pitch comes with the implicit confirmation that the Oberons have been watching the party since the Blushing Mermaid rejection.
+- Word reaches the party that the rival sponsored expedition has gone silent. The Oberons quietly request a recovery — body, journal, or artifact — without alerting the [Patriar Heritage Society](../../patriar-heritage-society/summary.md) salons.
+
+## See also
+
+- [High Moon Coster](../summary.md); [Oberon family](../people/oberon-family.md).
+- [Seven Suns](../../seven-suns/summary.md), [Iron Throne](../../iron-throne/summary.md) — sister remnants and possible co-sponsors.
+- Source: `faction-quests.xlsx` (High Moon Coster — *Sponsor an Adventuring Party*, *Finance the Smugglers*); `dm-notes.docx`.

--- a/20-Factions/iron-throne/README.md
+++ b/20-Factions/iron-throne/README.md
@@ -6,3 +6,4 @@ Remnant coster with shadowy, anonymous leadership; clinging to relevance after c
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-anonymous-throne.
+- [associations/](associations/) — Items, holdings, vehicles (rivington-recovery-group).

--- a/20-Factions/iron-throne/associations/README.md
+++ b/20-Factions/iron-throne/associations/README.md
@@ -1,0 +1,7 @@
+# Iron Throne — associations
+
+Items, holdings, and vehicles the faction guards.
+
+## Index
+
+- [rivington-recovery-group.md](rivington-recovery-group.md)

--- a/20-Factions/iron-throne/associations/rivington-recovery-group.md
+++ b/20-Factions/iron-throne/associations/rivington-recovery-group.md
@@ -1,0 +1,34 @@
+---
+name: rivington-recovery-group
+description: Iron Throne front company for distress-debt buying in the blockaded Outer City; outed in the Baldur's Mouth and rolled into intelligence brokerage.
+---
+
+# The Rivington Recovery Group
+
+A front company stood up by the [Iron Throne](../summary.md) during the blockade economy, ostensibly to "recover" failing Outer City businesses but in practice to acquire distress-debt and seize collateral at a fraction of pre-crisis value. Active in **Rivington** and **Blackgate**.
+
+## What it actually did
+
+- Quietly bought up the debts of small Outer City businesses on the verge of collapse during the [Free Traders](../../free-traders-of-the-outskirts/summary.md) blockade — taverns, smithies, caravan operators short on operating capital.
+- Acquired their inventory, leases, and equipment for a pittance when the borrowers defaulted.
+- Booked the gains under the Recovery Group's name rather than the Iron Throne's, insulating the family name from the inevitable backlash.
+
+## How it ended
+
+A clerk at the **Seatower of Balduran** (per `faction-quests.xlsx`) traced the Recovery Group's filings back to the Iron Throne and slipped the paper trail to a [Baldur's Mouth](../../baldurs-mouth/summary.md) reporter. The exposé ran under the masthead and burned the front overnight: tenants tore up notices, three planned foreclosures were physically blocked by Free Trader crowds, and the Throne's underworld credit took a public hit.
+
+## What replaced it
+
+The Throne pivoted the same week to **information brokerage** — selling intelligence on Archducal mercenary numbers, supply lines, and barricade plans, simultaneously, to both the [Free Traders](../../free-traders-of-the-outskirts/summary.md) and the [Guild](../../guild/summary.md). Maximum casualties on both sides, maximum gold to the Throne. (See `faction-quests.xlsx` *The Rumor Mill*, *The Double Cross*, *The Sabotage Brokerage*.)
+
+## Hooks
+
+- A burnt Outer City business owner approaches the party with the Recovery Group's foreclosure papers, asking for help recovering seized goods or extracting revenge on the Iron Throne agents who took them.
+- A surviving Recovery Group ledger — names, debts, collateral lists — is a piece of leverage the [Harpers](../../harpers/summary.md), the [Guild](../../guild/summary.md), or the [Free Traders](../../free-traders-of-the-outskirts/summary.md) would all pay handsomely for.
+- The Seatower clerk who leaked the story is a vulnerability the Throne would like to address quietly.
+
+## See also
+
+- [Iron Throne](../summary.md); [The Anonymous Throne](../people/the-anonymous-throne.md).
+- [Baldur's Mouth](../../baldurs-mouth/summary.md) — broke the story.
+- Source: `faction-quests.xlsx` (Iron Throne — *Scavenge the Scraps*, *The Rumor Mill*); `dossier-baldurs-gate-…` Part V Ch.12.

--- a/20-Factions/knights-of-the-shield/README.md
+++ b/20-Factions/knights-of-the-shield/README.md
@@ -6,3 +6,4 @@ Resurgent diabolist secret society recruiting dispossessed patriars in exchange 
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-recruiter.
+- [associations/](associations/) — Items, holdings, vehicles (soul-coins, the-infernal-ledger).

--- a/20-Factions/knights-of-the-shield/associations/README.md
+++ b/20-Factions/knights-of-the-shield/associations/README.md
@@ -1,0 +1,8 @@
+# Knights of the Shield — associations
+
+Items, holdings, and vehicles the faction guards.
+
+## Index
+
+- [soul-coins.md](soul-coins.md)
+- [the-infernal-ledger.md](the-infernal-ledger.md)

--- a/20-Factions/knights-of-the-shield/associations/soul-coins.md
+++ b/20-Factions/knights-of-the-shield/associations/soul-coins.md
@@ -1,0 +1,41 @@
+---
+name: soul-coins
+description: Infernal currency the Knights of the Shield demand from gate-locked Patriars in exchange for "guaranteed" protection during the Upper City lockdown.
+---
+
+# Infernal Soul-Coins
+
+The currency the [Knights of the Shield](../summary.md)'s recruiter — [the Hidden Lord](../people/the-recruiter.md) — demanded from trapped patriars during the Upper City **gate lockdown**, in exchange for "guaranteed" protection from the Lower City mobs. Per `faction-quests.xlsx`, *The Gilded Extortion*: the most lucrative single operation of the Knights' rebuild.
+
+## What they actually are
+
+Soul-coins are minted infernal currency — physical tokens, but the value is *the bound soul* of the bearer (or someone the bearer can offer). The Hells trade in them; merchants who deal at the Nine Hells / Material interface (a small set of devil-bound brokers, including some deep [Amnian Kontor](../../amnian-kontor/summary.md) accounts) accept them at a discount on actual debt.
+
+The Knights demand soul-coins specifically because:
+
+- They **launder cleanly** through devil-bound finance, leaving no Material-plane paper trail.
+- They **cost the patriar more than gold** — the patriar must either offer their own soul or arrange the binding of someone else's, deepening the patriar's own complicity.
+- They are **portable evidence** of the pact — the Knights keep duplicates as leverage.
+
+## What was extracted
+
+`faction-quests.xlsx` records the operation but not exact tallies. `dm-notes` confirms several Manorborn families paid; the gala-attending bloc was a primary target list (cross-reference [The "Baldurian Purity" Gala](../../patriar-heritage-society/associations/baldurian-purity-gala.md) for likely sub-list).
+
+## Vulnerabilities
+
+- A **single soul-coin** recovered intact and identified is enough to prove diabolism to the **Watchful Shield Shrine** priesthood — the same priests Lord Hlath already alerted.
+- The Knights' cooperating broker (the devil-bound contact who accepts the coins) is a single chokepoint. Take the broker, take the operation.
+- The patriars who paid are *also* leverage on the Knights — every soul-coin sold is a witness who would prefer the Knights silent.
+
+## Hooks
+
+- The party is hired (by the [Harpers](../../harpers/summary.md), by a Watchful Shield priest, by a guilty patriar) to **recover one soul-coin** as evidence — and to determine whose soul, exactly, is bound in it.
+- A patriar who paid begs the party to **break their own contract** before the Hells call the debt due.
+- The party encounters a soul-coin offered as payment for an unrelated job. Accepting it makes them visible to the same broker network — and to whatever is on the other side of it.
+
+## See also
+
+- [Knights of the Shield](../summary.md); [The Recruiter](../people/the-recruiter.md).
+- [The Infernal Ledger](the-infernal-ledger.md) — the recruiter's other major asset.
+- [Patriar Heritage Society](../../patriar-heritage-society/summary.md) — the demographic that paid.
+- Source: `faction-quests.xlsx` (Knights of the Shield — *The Gilded Extortion*); `dm-notes.docx`.

--- a/20-Factions/knights-of-the-shield/associations/the-infernal-ledger.md
+++ b/20-Factions/knights-of-the-shield/associations/the-infernal-ledger.md
@@ -1,0 +1,42 @@
+---
+name: the-infernal-ledger
+description: The blackmail dossier extracted from a bound Manorborn noble — Peerage of Blood voting history weaponized to swing Parliament votes.
+---
+
+# The Infernal Ledger
+
+The blackmail dossier the [Knights of the Shield](../summary.md) extracted from a recently-burgled **Manorborn noble** as the price of his "infernal protection" pact (per `faction-quests.xlsx`, *A Desperate Bargain* → *The Infernal Ledger*). The first concrete asset of the Knights' rebuild and the lever by which they have already moved a real Parliament vote.
+
+## What it contains
+
+The bound noble's **family journals**, covering decades of [Peerage of Blood](../../peerage-of-blood/summary.md) voting history — recorded informally, often with marginalia about which families traded which votes for what favors. The journals were maintained as a private record for the noble's children; the noble had no idea they amounted to a comprehensive map of patriar trade-policy logrolling.
+
+What the Knights' recruiter — codenamed [the Hidden Lord](../people/the-recruiter.md) — extracted from the journals:
+
+- A reliable list of **swing patriars** on trade-tariff legislation, with their historical price.
+- Names of patriars who have privately voted *against* the bloc on specific bills, never disclosed to the [Patriar Heritage Society](../../patriar-heritage-society/summary.md).
+- A short list of patriars whose voting history shows them *already amenable to outside influence* — natural follow-on recruitment targets for the Knights.
+
+## What it has done
+
+- **Swung a trade-tariff vote** in Parliament the week after extraction. The Hidden Lord blackmailed three named patriars with their own marginalia and forced them to vote against the Heritage Society line.
+- **Confirmed the Knights' operating model** — one good pact (the bound noble) is worth a dozen reported approaches (Lord Hlath, Marshal Flint, the Chionthar junior, the Guild Ward Boss).
+- **Profiled the next cohort.** The journals' margins gave the recruiter at least two new approach candidates without him having to be seen near them.
+
+## Vulnerabilities
+
+- A copy of the Ledger in the wrong hands (the [Harpers](../../harpers/summary.md), the [Patriar Heritage Society](../summary.md) itself, or a rival cult) would unwind every blackmail it has enabled.
+- The **bound noble** still lives. He knows the recruiter's face. The Knights treat him as an asset; he is also a single point of failure.
+- The **Watchful Shield Shrine** priesthood — alerted by Lord Hlath — is actively listening for any rumor of "patriar votes for sale," which is exactly the smell the Ledger leaves behind.
+
+## Hooks
+
+- Recover the Ledger for the [Harpers](../../harpers/summary.md), the Watchful Shield priests, or [Lord Corin Durinbold](../../peerage-of-blood/people/corin-durinbold.md) — each pays differently and the price says who you've sided with.
+- Extract the bound noble before the Knights decide he is a liability rather than an asset.
+- Read the Ledger yourself — for any party considering its own move on the Peerage of Blood, this is the map.
+
+## See also
+
+- [Knights of the Shield](../summary.md); [The Recruiter](../people/the-recruiter.md).
+- [Peerage of Blood](../../peerage-of-blood/summary.md); [Patriar Heritage Society](../../patriar-heritage-society/summary.md).
+- Source: `faction-quests.xlsx` (Knights of the Shield — *A Desperate Bargain*, *The Infernal Ledger*).

--- a/20-Factions/patriar-heritage-society/README.md
+++ b/20-Factions/patriar-heritage-society/README.md
@@ -5,3 +5,4 @@ Nativist patriar club organizing the Peerage of Blood as a unified voting bloc.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [associations/](associations/) — Items, holdings, vehicles (baldurian-purity-gala, silver-fist-fund).

--- a/20-Factions/patriar-heritage-society/associations/README.md
+++ b/20-Factions/patriar-heritage-society/associations/README.md
@@ -1,0 +1,8 @@
+# Patriar Heritage Society — associations
+
+Items, holdings, and vehicles the faction guards.
+
+## Index
+
+- [baldurian-purity-gala.md](baldurian-purity-gala.md)
+- [silver-fist-fund.md](silver-fist-fund.md)

--- a/20-Factions/patriar-heritage-society/associations/baldurian-purity-gala.md
+++ b/20-Factions/patriar-heritage-society/associations/baldurian-purity-gala.md
@@ -1,0 +1,39 @@
+---
+name: baldurian-purity-gala
+description: Durinbold's invitation-only gala for the Peerage of Blood — a political rally dressed as a society function, endorsing the Flaming Fist and isolating the Archduke.
+---
+
+# The "Baldurian Purity" Gala
+
+An exclusive, invitation-only gala hosted by [Lord Corin Durinbold](../../peerage-of-blood/people/corin-durinbold.md) at the height of the trade-war crisis, ostensibly a society function but in practice a [Patriar Heritage Society](../summary.md) **political rally** — celebrating "Baldurian tradition," endorsing Marshal **Valerius Flint** and the [Flaming Fist](../../flaming-fist/summary.md), and publicly isolating Archduke **Lyra Silvershield**.
+
+## What it actually was
+
+Per `dm-notes` and the [Baldur's Mouth](../../baldurs-mouth/summary.md) week-3 coverage, the gala served three functions:
+
+- **Endorsement signal.** The full social weight of the [Peerage of Blood](../../peerage-of-blood/summary.md) — Durinbold, Jannath, Oberon, and others — visibly backed Marshal Flint as the *symbol of the old Baldurian order*, after the Archduke moved to remove him.
+- **Counter-narrative.** The slogan "Baldurian Purity" was deployed as a respectable wrapper for a politics targeting the foreign Kontors, the Merchant Consortiums, and the Archduke personally. Toasts named names; the [Amnian Kontor](../../amnian-kontor/summary.md) and the [Western Gate Trading Company](../../western-gate-trading-company/summary.md) were singled out.
+- **Conspicuous absence list.** Who *wasn't* invited mattered as much as who was: no Coin members, no Kontor consuls, no Council of Four representatives. The exclusion was intentional and broadcast.
+
+## Outputs
+
+- Public momentum behind the **defense of Marshal Flint**, blunting the Coin motion to replace the Fist with foreign mercenaries.
+- A list of attendees that effectively *defined* the active Heritage Society membership going into the rest of the crisis — useful intelligence for any faction trying to map the bloc.
+- Cover for the launch of the [Silver Fist loyalty fund](silver-fist-fund.md), which began distributing the same week.
+
+## Vulnerabilities
+
+- The **guest list** itself, if leaked, lets the [Harpers](../../harpers/summary.md) or the [Baldur's Mouth](../../baldurs-mouth/summary.md) document the bloc's composition for the first time.
+- Any patriar conspicuously *missing* (e.g., the [Hlath family](../../patriar-heritage-society/summary.md) post-foreclosure) is identifiably weakened — and a known target for the [Knights of the Shield](../../knights-of-the-shield/summary.md) recruiter.
+- Toasts overheard by serving staff are the kind of evidence the [Bibliophile](../../bibliophile/summary.md) buys without asking why.
+
+## Hooks
+
+- The party is offered a serving-staff cover by the [Harpers](../../harpers/summary.md) to attend, listen, and lift the guest list — paying in *whichever* faction's coin most needs the bloc named.
+- A second gala is being planned to mark the gate lockdown's end. Sponsorship and invitations are openly for sale to the right family.
+
+## See also
+
+- [Patriar Heritage Society](../summary.md); [Silver Fist loyalty fund](silver-fist-fund.md).
+- [Lord Corin Durinbold](../../peerage-of-blood/people/corin-durinbold.md); [Peerage of Blood](../../peerage-of-blood/summary.md).
+- Source: `dm-notes.docx`; `baldurs-mouth.docx` (week 3).

--- a/20-Factions/patriar-heritage-society/associations/silver-fist-fund.md
+++ b/20-Factions/patriar-heritage-society/associations/silver-fist-fund.md
@@ -1,0 +1,38 @@
+---
+name: silver-fist-fund
+description: The Patriar Heritage Society's slush fund used to bribe Flaming Fist sergeants and manips into slow-rolling Marshal Flint's orders.
+---
+
+# The "Silver Fist" Loyalty Fund
+
+A massive purse collected from [Patriar Heritage Society](../summary.md) families and quietly distributed as silver "bonuses" to [Flaming Fist](../../flaming-fist/summary.md) sergeants, manips, and a handful of cooperative blazes — buying rank-and-file loyalty to the *old guard* rather than to Marshal **Valerius Flint** and his Githyanki allies. Coordinated by [Lord Corin Durinbold](../../peerage-of-blood/people/corin-durinbold.md); the brand "Silver Fist" appears in `dm-notes.docx`.
+
+## Where the money comes from
+
+- Heritage Society families — Durinbold first, with contributions documented from Jannath, Oberon, and (before the foreclosure) Hlath.
+- Loaned in **silver**, not gold, to keep individual bribes deniable as drinking-pay or family-day bonuses rather than overt patronage.
+- Distributed at **The Elfsong Tavern**, where Fist officers congregate off-duty — the venue is the cover.
+
+## What it has bought
+
+- **The Officer's Dilemma.** Bribed officers are now deliberately slow-rolling Flint's smuggling crackdown and his orders to disperse the [Free Traders](../../free-traders-of-the-outskirts/summary.md) blockade. Per `dm-notes`, Durinbold's bribery campaign has "succeeded": the Fist is *paralyzed*.
+- **A defensive shield around the Marshal.** When the Archduke moved to oust Flint, the Heritage Society's bought officers refused to enforce the no-confidence vote at the barracks level, contributing to the deadlock.
+- **Quiet eyes** on Fist patrol routes — useful when a Heritage Society household needs an "undesirable" cleared without a formal complaint.
+
+## Vulnerabilities
+
+- The **paymaster paper trail** runs through Durinbold's house steward. Any party that pulls the steward, or the Elfsong's till-book, gets the names.
+- The Fist's Githyanki-aligned faction (the [Unchained](../../unchained/summary.md) embeds working with Flint) suspect the bribe but cannot prove it without one of those names.
+- A single bribed officer caught in the act — taken to the [Baldur's Mouth](../../baldurs-mouth/summary.md) by the [Harpers](../../harpers/summary.md) — would unravel the whole fund.
+
+## Hooks
+
+- The party is approached by Flint himself, or by his Unchained-aligned aides, to extract proof of the Silver Fist bribes from the Elfsong or the Durinbold steward.
+- The party is offered a Silver Fist bonus to look the other way on a Heritage Society operation, or to *not* report what they saw at the gate lockdown.
+- The fund's collapse would *also* collapse the Heritage Society's defense of the Fist — and re-open the door to the foreign-mercenary motion they have so far blocked.
+
+## See also
+
+- [Patriar Heritage Society](../summary.md); [Lord Corin Durinbold](../../peerage-of-blood/people/corin-durinbold.md).
+- [Flaming Fist](../../flaming-fist/summary.md); the Officer's Dilemma.
+- Source: `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/seven-suns/README.md
+++ b/20-Factions/seven-suns/README.md
@@ -6,3 +6,4 @@ Remnant coster led by the Jhasso family; fortunes dwindling after Calimshan trad
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: jhasso-family.
+- [associations/](associations/) — Items, holdings, vehicles (the-captive-market).

--- a/20-Factions/seven-suns/associations/README.md
+++ b/20-Factions/seven-suns/associations/README.md
@@ -1,0 +1,7 @@
+# Seven Suns — associations
+
+Items, holdings, and vehicles the faction guards.
+
+## Index
+
+- [the-captive-market.md](the-captive-market.md)

--- a/20-Factions/seven-suns/associations/the-captive-market.md
+++ b/20-Factions/seven-suns/associations/the-captive-market.md
@@ -1,0 +1,30 @@
+---
+name: the-captive-market
+description: The Seven Suns' lost Calimshan silk run — the financial event that has the Jhasso family canvassing for non-foreclosing creditors.
+---
+
+# The Captive Market
+
+The single most consequential recent event for the [Seven Suns](../summary.md): a Calimshan silk and southern-spice expedition that was lost en route, dealing a major blow to the [Jhasso family](../people/jhasso-family.md)'s already dwindling fortunes. Named after the `faction-quests.xlsx` row that records it.
+
+## What was lost
+
+A full-cargo run of **Calimshan silks** plus a smaller consignment of southern spices and bound books. The vessel was lost on the Sea of Swords to a combination of weather and piracy — the dossier and worksheets do not commit which source did the actual sinking. The cargo was uninsured at full value; the family's standing insurance broker (an [Amnian Kontor](../../amnian-kontor/summary.md) underwriter) had already capped exposure on Seven Suns runs after the previous bad season.
+
+## Why it matters
+
+- It is the trigger for the family's quiet creditor-canvassing. The Jhassos cannot accept the [Amnian Kontor](../../amnian-kontor/summary.md)'s standing terms — those terms broke the [Hlath family](../../patriar-heritage-society/summary.md) — but they are running out of houses willing to lend without taking the manor as collateral.
+- It explains the **manor-as-collateral** pattern: salons of the Manorborn manor are hosting more and more private buyers, with paintings, plate, and bound books moved out one at a time against the next shipment.
+- It marks the Seven Suns as **soft enough to acquire** — a fact the [Chionthar Consortium](../../chionthar-consortium/summary.md) has noticed, the Amnians have priced, and the [Knights of the Shield](../../knights-of-the-shield/summary.md) recruiter would file as a future approach.
+
+## Hooks
+
+- A Jhasso elder hires the party to **recover the cargo** — or to determine, with proof, which of weather or piracy actually did the sinking. The answer matters: a piracy finding lets the family pursue their underwriter for full payout instead of a partial loss.
+- A specific Jhasso heirloom (a bound book, a piece of plate) is about to go to **Amnian auction** as part of the creditor's collection. Quiet retrieval — by purchase or otherwise — would buy the family a season.
+- A second silk run is being prepared. The Jhassos cannot afford a competent escort; an adventuring party willing to take a percent against a low purse could be auditioned, much as the [High Moon Coster](../../high-moon-coster/summary.md) did at the Blushing Mermaid.
+
+## See also
+
+- [Seven Suns](../summary.md); [Jhasso family](../people/jhasso-family.md).
+- [Amnian Kontor](../../amnian-kontor/summary.md) — circling underwriter / creditor.
+- Source: `faction-quests.xlsx` (Seven Suns — *The Captive Market*); `dossier-baldurs-gate-…` Part V Ch.12.


### PR DESCRIPTION
## Summary

Follow-up to #16 (already merged) — adds depth to the six batch-5 factions without growing existing summaries past the 500-word ceiling.

New files capture specific operations, items, and holdings the summaries previously only referenced in passing:

- **Iron Throne** — `associations/rivington-recovery-group.md` (the outed front company → pivot to information brokerage)
- **Seven Suns** — `associations/the-captive-market.md` (lost Calimshan run; manor-as-collateral; creditor-canvassing)
- **High Moon Coster** — `associations/cloakwood-expedition.md` (current sponsored party; rejected PC offer; rival-party hooks)
- **Patriar Heritage Society** — `associations/silver-fist-fund.md` (bribery slush fund driving the Officer's Dilemma) and `associations/baldurian-purity-gala.md` (Durinbold's gala)
- **Knights of the Shield** — `associations/the-infernal-ledger.md` (bound noble's voting journals → tariff-vote swing) and `associations/soul-coins.md` (gate-lockdown extortion currency)
- **Baldur's Mouth** — `associations/credential-of-balduran.md` (press signet held by Kaelan), `associations/heapside-print-shop.md` (patron book, Whispering Stones presence), `people/the-interim-management-board.md` (post-kidnapping editorship)

All new files are 380–498 words. `scaffold_factions.py` is idempotent.

## Test plan

- [ ] Spot-check cross-links resolve (relative paths to peer faction summaries)
- [ ] Re-run `uv run python src/ingest/scaffold_factions.py` and confirm no further diffs
- [ ] Confirm each new file is under 500 words per CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)