### PR TITLE
Fill 12 Worshipful Company faction folders (batch 3)

### DIFF
--- a/20-Factions/wc-alchemists-apothecaries/README.md
+++ b/20-Factions/wc-alchemists-apothecaries/README.md
@@ -5,3 +5,4 @@ Secretive guild controlling potions, antitoxins, and other exotic substances.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: phineas-droog.

--- a/20-Factions/wc-alchemists-apothecaries/people/README.md
+++ b/20-Factions/wc-alchemists-apothecaries/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Alchemists & Apothecaries — people
+
+Named figures.
+
+## Index
+
+- [phineas-droog.md](phineas-droog.md)

--- a/20-Factions/wc-alchemists-apothecaries/people/phineas-droog.md
+++ b/20-Factions/wc-alchemists-apothecaries/people/phineas-droog.md
@@ -1,0 +1,28 @@
+---
+name: phineas-droog
+description: Master of the Alchemists' Company; eccentric, paranoid, and now scrambling to contain a leak of his own making.
+---
+
+# Master Phineas Droog
+
+Master of the [Worshipful Company of Alchemists & Apothecaries](../summary.md). Eccentric, paranoid, and deeply protective of the formulas his guild monopolizes — to the point of being unable to distinguish a real threat from one of his own making.
+
+## Manifesto
+
+> Flesh is a chemical equation. Sickness, strength, life, death — they are all merely formulas waiting to be written. The gods offer prayers; we offer cures. The assassins offer blades; we offer poisons that leave no trace. We hold the secrets to the body's machinery, and for the right price, we will happily provide the key to wind it up or shut it down.
+
+## Role
+
+Droog rose during the post-crisis sickness years, when the demand for legal potions and antitoxins outstripped supply and the Company's charter became a license to print coin. He has run the guild since with the instincts of someone who believes the entire city is trying to steal his recipes — sometimes correctly.
+
+His current crises:
+
+- A **price-gouging vote** to triple antitoxin prices during a Sewer Plague outbreak was bypassed when adventurers diverted [Chionthar Consortium](../../chionthar-consortium/summary.md) supplies to the Open Hand Temple. The guild's public reputation took a sharp hit; Droog took the rebuff personally.
+- A **theft from the Company's own stores** of dangerous reagents was covered up by publicly framing a recently-fired apprentice and posting a bounty for him. The plan has now collapsed: the apprentice has reached out to [the Guild](../../guild/summary.md) offering three valuable formulas in exchange for protection and safe passage.
+
+He maintains the Company's legendary cold war with the un-chartered **Poisoners' Guild**, but the immediate threat to his position now comes from inside his own walls. He is, predictably, hunting harder for traitors and trusting fewer of his Wardens.
+
+## See also
+
+- [Worshipful Company of Alchemists & Apothecaries](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-alchemists-apothecaries/summary.md
+++ b/20-Factions/wc-alchemists-apothecaries/summary.md
@@ -5,14 +5,28 @@ description: Secretive guild controlling potions, antitoxins, and other exotic s
 
 # Worshipful Company of Alchemists & Apothecaries
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that owns the legal pharmacopoeia of Baldur's Gate — every healing potion, antitoxin, and licensed reagent. In a crowded city plagued by sickness and violence, their charter is effectively a license to print coin. Led by [Master Phineas Droog](people/phineas-droog.md).
 
 ## Ideology
 
+To control the flow of alchemical substances and the secrets behind them. The Company casts itself as pragmatic scientists holding the line against superstition; in practice, it operates as a guild of monopolists who treat the city's health as a price-list to be tuned.
+
 ## Membership
+
+The city's most skilled alchemists, apothecaries, and (off the books) poisoners. Master / Wardens / Court of Assistants framework, with an unusually paranoid security culture under Droog. Apprentices are kept on long, restrictive contracts; recent firings have not gone quietly.
 
 ## Methods
 
+- Sets prices on every legal potion and antitoxin in the city, and is the only legal purveyor of most of them.
+- Industrial espionage to steal formulas from rivals — and brutal protection of its own.
+- Following a minor Sewer Plague outbreak in the Lower City, the **Court of Assistants voted to triple antitoxin prices**, citing reagent scarcity. The move was naked price-gouging; an adventuring party bypassed the guild entirely by routing supplies from a [Chionthar Consortium](../chionthar-consortium/summary.md) warehouse to the Open Hand Temple, earning Droog's private fury.
+- After dangerous reagents were stolen from the guild's own stores, Droog publicly accused a fired apprentice of the theft and posted a bounty — a convenient scapegoat. The framed apprentice has now opened back-channel negotiations with [the Guild](../guild/summary.md), offering three valuable potion formulas in exchange for safe passage.
+
 ## Hooks and Relationships
 
+**Enemies.** Legendary cold war with the un-chartered **Poisoners' Guild**, which operates as the Company's illegal black-market mirror. Distrust from the city's temples — particularly the Open Hand — who see the Alchemists as amoral profiteers. Hostile gaze from [The Purified](../purified/summary.md), whose conspiracy theory holds that the Alchemists secretly supply chemical binders for Lantaner nano-cogs. The current apprentice scandal threatens to put guild secrets directly in [the Guild](../guild/summary.md)'s hands, a potentially catastrophic leak.
+
 ## See also
+
+- [Master Phineas Droog](people/phineas-droog.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-butchers-tanners/README.md
+++ b/20-Factions/wc-butchers-tanners/README.md
@@ -5,3 +5,4 @@ Wealthy but socially disdained guild controlling food and leather production.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: borlu.

--- a/20-Factions/wc-butchers-tanners/people/README.md
+++ b/20-Factions/wc-butchers-tanners/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Butchers & Tanners — people
+
+Named figures.
+
+## Index
+
+- [borlu.md](borlu.md)

--- a/20-Factions/wc-butchers-tanners/people/borlu.md
+++ b/20-Factions/wc-butchers-tanners/people/borlu.md
@@ -1,0 +1,29 @@
+---
+name: borlu
+description: Master of the Butchers' Company; "the Cleaver" — proud, brutal, and currently buying off a public-health scandal.
+---
+
+# Goodman Borlu, "the Cleaver"
+
+Master of the [Worshipful Company of Butchers & Tanners](../summary.md). Tough as old leather, openly proud of a trade the patriars find embarrassing, and disinclined to apologize for either.
+
+## Manifesto
+
+> Let the perfumed lords and ladies look down their noses at us. Let them wrinkle their noses at the smell of our tanneries and the blood in our gutters. When their bellies rumble, they eat our meat. When they need a sturdy belt for their sword, they wear our leather. We are the foundation of this city's life, and our wealth is as real as the blood on our hands. We are not ashamed of our work, for it is the work of life and death.
+
+## Role
+
+Borlu rose through the slaughterhouses and runs the Company as a tight, clannish operation built on territorial defense and price control. The Wardens under his command are notorious — bone-breakers more than inspectors — and his peers across the [Worshipful Companies](../../README.md) treat him as the guild least likely to be reasoned out of a fight.
+
+His current crises are all his own work:
+
+- **Tannery runoff dumping** into a Chionthar tributary has poisoned water for miles downstream and made him the [Circle of the Inner Grove](../../circle-of-the-inner-grove/summary.md)'s standing target.
+- A clumsy attempt to **intimidate a city health inspector** failed publicly; the inspector's damning report has triggered fines and Council scrutiny.
+- A **spoiled-meat scheme** — selling contaminated rations through the Sow's Foot — was caught by a [Hellriders of New Elturel](../../hellriders-of-new-elturel/summary.md) patrol on contamination alert. Borlu is now meeting **Ettvard Needle** at the [Baldur's Mouth](../../baldurs-mouth/summary.md) print shop, offering a substantial bribe to bury the story and replace it with puff coverage about "generous food donations" to the Outer City poor.
+
+He is locked in a leather-rights rivalry with [Mistress Elethra Vance](../../wc-mercers-clothiers/people/elethra-vance.md), whom he openly dislikes.
+
+## See also
+
+- [Worshipful Company of Butchers & Tanners](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-butchers-tanners/summary.md
+++ b/20-Factions/wc-butchers-tanners/summary.md
@@ -5,14 +5,29 @@ description: Wealthy but socially disdained guild controlling food and leather p
 
 # Worshipful Company of Butchers & Tanners
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that handles the city's bloodiest essential work. Ancient and wealthy, but kept off the patriars' guest lists by the smell and stigma of the trade. The combination has made the Butchers and Tanners fiercely proud, fiercely clannish, and fiercely resentful — a guild with the money of the city's elite and the social standing of its slaughter-yard workers. Led by [Goodman Borlu, "the Cleaver"](people/borlu.md).
 
 ## Ideology
 
+To protect the Company's commercial monopoly on meat and leather, and to demand the social respect their wealth has not bought them. The internal narrative is unapologetic: "the work of life and death" is the foundation of the city, and they refuse to be shamed for it.
+
 ## Membership
+
+The owners of the city's slaughterhouses, butcher shops, and tanneries. The standard Master / Wardens / Court of Assistants framework, with a Wardens corps notorious for brutality. Borlu — a man as tough as old leather — leads from inside the guild's industrial-district stronghold.
 
 ## Methods
 
+- Sets the price and supply of meat and leather across the city.
+- Wardens are brutal with anyone who infringes on territory, rustles livestock shipments, or competes on price.
+- **Dumps toxic tannery runoff** into a Chionthar tributary under cover of darkness rather than pay for proper disposal — poisoning the water for miles downstream and igniting open hostilities with the [Circle of the Inner Grove](../circle-of-the-inner-grove/summary.md).
+- A failed attempt to **intimidate a city health inspector** backfired publicly: the inspector was either too brave or too well-protected, and his damning pollution report has triggered a hefty fine and unwanted Council scrutiny of Borlu's tanneries.
+- Currently mid-disaster on a **spoiled-meat scheme**: a Hellrider patrol seized a contaminated rations shipment at Sow's Foot before it could be sold, exposing the Company to legal action and public fury. Borlu's response — meeting **Ettvard Needle** at the [Baldur's Mouth](../baldurs-mouth/summary.md) print shop with a massive bribe to kill the story and run a "generous food donation" puff piece — is now in flight.
+
 ## Hooks and Relationships
 
+**Enemies.** Open war with the [Circle of the Inner Grove](../circle-of-the-inner-grove/summary.md), whose druids treat the tanneries' runoff as targets for sabotage. Bitter leather rivalry with the [Worshipful Company of Mercers & Clothiers](../wc-mercers-clothiers/summary.md). Newly hostile relationship with the [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) after the Sow's Foot rations seizure. The [Council of Four](../council-of-four/summary.md) is now scrutinizing the Company's pollution record.
+
 ## See also
+
+- [Goodman Borlu, "the Cleaver"](people/borlu.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-cartographers-surveyors/README.md
+++ b/20-Factions/wc-cartographers-surveyors/README.md
@@ -5,3 +5,4 @@ Essential guild whose seal is required on every land deed; closely guarded sewer
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: elias-vancroft.

--- a/20-Factions/wc-cartographers-surveyors/people/README.md
+++ b/20-Factions/wc-cartographers-surveyors/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Cartographers & Surveyors — people
+
+Named figures.
+
+## Index
+
+- [elias-vancroft.md](elias-vancroft.md)

--- a/20-Factions/wc-cartographers-surveyors/people/elias-vancroft.md
+++ b/20-Factions/wc-cartographers-surveyors/people/elias-vancroft.md
@@ -1,0 +1,29 @@
+---
+name: elias-vancroft
+description: Master of the Cartographers' Company; sells the city's geography to whoever pays the most, often twice.
+---
+
+# Master Elias Vancroft
+
+Master of the [Worshipful Company of Cartographers & Surveyors](../summary.md). Precise, politically astute, and willing to sell the same map to two enemies if both are paying.
+
+## Manifesto
+
+> The world is a chaotic, illegible scroll until we give it shape. We draw the lines that become borders, the paths that become trade routes, the squares that become property. A merchant cannot own what is not measured. An army cannot conquer what is not mapped. We do not merely copy the world; we define it. And in defining it, we control it.
+
+## Role
+
+Vancroft built his reputation during the post-crisis property-line scramble, when every patriar and every merchant needed a Cartographers' seal to make their land claims real. He turned the Company's monopoly on legal cartography into a quiet but durable form of leverage: the seal is law, and the seal belongs to him.
+
+His current operations:
+
+- Sold "exclusive" Trollclaws passage maps to two rival caravan masters, pocketing both fees on a route the Company knows to be dangerous.
+- Tasked his surveyors with drawing tactical maps of the **Basilisk Gate blockade** and **Wyrm's Rock fortifications**, then began selling them to every interested party — first the Archduke's forces, then a duplicate set to **Mad Meggan**'s lieutenants of the [Free Traders of the Outskirts](../../free-traders-of-the-outskirts/summary.md). His Company is now profiting from both sides of the conflict.
+- A favor for the [Western Gate Trading Company](../../western-gate-trading-company/summary.md) — to "lose" an inconvenient land deed by silencing the minor patriar holding it — collapsed when the patriar evaded the planned accident and filed the deed publicly. The Trading Company is exposed; Vancroft is exposed with them.
+
+He treats [the Guild](../../guild/summary.md)'s ongoing interest in his sewer maps as a permanent, manageable threat, and is acutely aware that his current double-dealing across the blockade is one whisper away from getting him killed by either side.
+
+## See also
+
+- [Worshipful Company of Cartographers & Surveyors](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-cartographers-surveyors/summary.md
+++ b/20-Factions/wc-cartographers-surveyors/summary.md
@@ -5,14 +5,30 @@ description: Essential guild whose seal is required on every land deed; closely 
 
 # Worshipful Company of Cartographers & Surveyors
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that defines the city, on parchment. A Cartographers' seal is legally required on every land deed in Baldur's Gate, every new trade route filed for sale, and every property-line dispute heard before the magistrates. The frantic post-crisis reconstruction made them indispensable; the new trade routes that followed gave them durable, near-invisible power. Led by [Master Elias Vancroft](people/elias-vancroft.md).
 
 ## Ideology
 
+To be the sole, trusted source of geographic and property information in the region. The Company holds that "accuracy is a sacred duty" — and that, as a corollary, the privilege of defining accuracy belongs entirely to them.
+
 ## Membership
+
+The city's most meticulous cartographers, surveyors, and architects, organized along Master / Wardens / Court of Assistants lines. Vancroft runs the guild as a precise, politically astute operation; corruption inside the Company is plausibly deniable rather than clean.
 
 ## Methods
 
+- Every land deed in Baldur's Gate carries a Cartographers' seal — the legal requirement gives them quiet veto over real estate.
+- Sells maps of trade routes to merchant consortiums at premium prices, including, by reputation, the most detailed sewer and undercity maps in the city. The sewer maps are a closely guarded secret and a constant target.
+- Routine fraud as policy:
+  - **Sold "exclusive" Trollclaws maps** of a "newly discovered, safe passage" to two competing caravan masters, pocketing both fees. The route is notoriously dangerous.
+  - **Tactical maps of the Basilisk Gate blockade and Wyrm's Rock**, drawn by Vancroft's surveyors, are now being sold to every interested party — the Archduke's forces and Mad Meggan's lieutenants alike.
+- A **failed deed manipulation** for the [Western Gate Trading Company](../western-gate-trading-company/summary.md) — silencing a minor patriar and "losing" an inconvenient deed — collapsed when the patriar avoided the planned accident and filed the deed publicly. The Trading Company now faces a major property-claim crisis, and the Cartographers' role in the affair is increasingly visible.
+
 ## Hooks and Relationships
 
+**Enemies.** [The Guild](../guild/summary.md) is a permanent espionage threat — they want the secret sewer maps, and Vancroft knows it. Rival merchant consortiums treat the Company as both supplier and adversary, depending on the week. The [Western Gate Trading Company](../western-gate-trading-company/summary.md) is exposed and angry over the failed deed scheme. Mad Meggan and the [Free Traders of the Outskirts](../free-traders-of-the-outskirts/summary.md) are now buying maps that the Archduke's forces are also buying — a profitable but dangerous balancing act.
+
 ## See also
+
+- [Master Elias Vancroft](people/elias-vancroft.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-chandlers-lamplighters/README.md
+++ b/20-Factions/wc-chandlers-lamplighters/README.md
@@ -5,3 +5,4 @@ Provides oil, candles, and torches; lamplighter crews know the city's nightly rh
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: anya-brightwood.

--- a/20-Factions/wc-chandlers-lamplighters/people/README.md
+++ b/20-Factions/wc-chandlers-lamplighters/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Chandlers & Lamplighters — people
+
+Named figures.
+
+## Index
+
+- [anya-brightwood.md](anya-brightwood.md)

--- a/20-Factions/wc-chandlers-lamplighters/people/anya-brightwood.md
+++ b/20-Factions/wc-chandlers-lamplighters/people/anya-brightwood.md
@@ -1,0 +1,29 @@
+---
+name: anya-brightwood
+description: Master of the Chandlers' Company; civic-minded face, runs the city's best informal night-watch network.
+---
+
+# Mistress Anya Brightwood
+
+Master of the [Worshipful Company of Chandlers & Lamplighters](../summary.md). Civic-minded in public, practical-minded in the back room: her lamplighter crews see more of the city after dark than the [Flaming Fist](../../flaming-fist/summary.md) does, and she knows it.
+
+## Manifesto
+
+> The night is a beast that preys on this city. It hides the cutthroat, the cultist, and the creature. We are the ones who hold it at bay. Every candle in a window, every torch in a scabbard, every lamp on a street corner is a shield we have provided. We do not sell wax and oil; we sell safety. We sell civilization. We sell the light.
+
+## Role
+
+Brightwood runs both halves of the Company — wax and oil supply, and the contracted lamplighter crews — as a single integrated operation. Her current operations:
+
+- **Renewed the standing five-year city lamplighting contract** with the [Council of Four](../../council-of-four/summary.md), locking in profits and civic relevance for the foreseeable future.
+- **Won a Norchapel expansion contract** for the Outer City, and quietly tasked her crews to act as a low-level intelligence network — discreetly reporting unusual activity from their nightly rounds.
+- Cut a discreet deal with [the Guild](../../guild/summary.md): in exchange for protection of her crews in the city's roughest streets, she provides a Ward-Boss with periodic lists of "malfunctioning" lamps — manufactured **dark zones** for the Guild's ambushes and smuggling routes.
+
+That arrangement has now been blown. A [Zhentarim](../../zhentarim/summary.md) agent in Eastway caught one of her lamplighters out, interrogated him, and walked away with the network's loyalties confirmed. The Zhentarim can now feed false information through her informants directly into the Guild — a problem she has not yet solved.
+
+She remains a standing target of the **Silent Choir** cult, which sees the city's lights as the obstacle to its work.
+
+## See also
+
+- [Worshipful Company of Chandlers & Lamplighters](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-chandlers-lamplighters/summary.md
+++ b/20-Factions/wc-chandlers-lamplighters/summary.md
@@ -5,14 +5,30 @@ description: Provides oil, candles, and torches; lamplighter crews know the city
 
 # Worshipful Company of Chandlers & Lamplighters
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that holds back the dark. In a city without magical lighting in its poorer districts, the Chandlers' candles, oils, and street-torches are not luxuries — they are the precondition for night-time movement. The contracted **Lamplighter** crews who walk the streets at dusk and dawn double, in practice, as the city's most knowledgeable witnesses. Led by [Mistress Anya Brightwood](people/anya-brightwood.md).
 
 ## Ideology
 
+To preserve the Company's role as the line between civilization and the dark, and the steady profits that come with it. Self-image: a force for safety and order. Self-interest: a network of crews who happen to know which streets are quiet, which are busy, and which would benefit from being suddenly unlit.
+
 ## Membership
+
+Candlemakers, oil merchants, and the organized crews of lamplighters. The Master / Wardens / Court of Assistants framework is unusually tight; Brightwood runs the lamplighter shifts the way the [Flaming Fist](../flaming-fist/summary.md) wishes it could run patrols. Civic-minded face, sharp-elbowed practice.
 
 ## Methods
 
+- Controls the supply of lamp oil and high-quality wax, and the city's standing **lamplighting contract** with the [Council of Four](../council-of-four/summary.md) — recently renewed for five years, locking in profits and civic relevance.
+- Lamplighter crews function as an informal intelligence network: under a recent expansion contract for **Norchapel** in the Outer City, the crews are quietly reporting unusual activity from their nightly rounds.
+- Has cut a dirty side deal with [the Guild](../guild/summary.md): in exchange for protection of lamplighter crews in dangerous neighborhoods, Brightwood provides a Guild Ward-Boss with a list of "malfunctioning" streetlamps — pre-fabricated **dark zones** ideal for ambush or smuggling.
+- That arrangement is now compromised: a sharp-eyed [Zhentarim](../zhentarim/summary.md) agent in Eastway noticed the unusual scrutiny from one crew, ambushed and interrogated a lamplighter, and the network's allegiance is now exposed. The Zhentarim can — and will — feed the Guild false intelligence through it.
+
 ## Hooks and Relationships
 
+**Allies.** [The Guild](../guild/summary.md) (informant relationship; now compromised); the [Council of Four](../council-of-four/summary.md) on the standing lamp contract.
+
+**Enemies.** Street muggers and burglars who profit from extinguished lamps. The **Silent Choir** cult, which seeks to plunge the city's lamps into permanent dark. [Zhentarim](../zhentarim/summary.md) — newly hostile, now equipped to weaponize the Lamplighters' Guild loyalty.
+
 ## See also
+
+- [Mistress Anya Brightwood](people/anya-brightwood.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-fishmongers/README.md
+++ b/20-Factions/wc-fishmongers/README.md
@@ -5,3 +5,4 @@ Ancient guild controlling Gray Harbour fishing fleets; food supply leverage.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: marga-saltwind.

--- a/20-Factions/wc-fishmongers/people/README.md
+++ b/20-Factions/wc-fishmongers/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Fishmongers — people
+
+Named figures.
+
+## Index
+
+- [marga-saltwind.md](marga-saltwind.md)

--- a/20-Factions/wc-fishmongers/people/marga-saltwind.md
+++ b/20-Factions/wc-fishmongers/people/marga-saltwind.md
@@ -1,0 +1,29 @@
+---
+name: marga-saltwind
+description: Master of the Fishmongers' Company; controls the city's primary protein source and the dockworker vote.
+---
+
+# Matron Marga Saltwind
+
+Master of the [Worshipful Company of Fishmongers](../summary.md). Tough, plain-spoken, and politically unsentimental — she runs Gray Harbour the way her grandmother ran a gutting shed.
+
+## Manifesto
+
+> The patriars feast on imported wine, but the city runs on herring. Before the walls, before the Dukes, there was the harbor. There was the sea. We are the blood of old Baldur's Gate, and our nets feed the tens of thousands who do the city's real work. Let the other guilds play with their gold and their laws. We control the tide and the table.
+
+## Role
+
+Saltwind inherited a Company older than the city's modern government and runs it as a labor coalition disguised as a guild. The Fishmongers' real asset is not fish — it is the unionized dockworkers and sailors who process it, and the political weight they swing in the [Peerage of Coin](../../peerage-of-coin/summary.md).
+
+Her current operations:
+
+- A **dockworker strike** to extract concessions on harbor taxes was crushed within hours when the [Chionthar Consortium](../../chionthar-consortium/summary.md) preemptively imported non-union labor from New Elturel refugees, splitting Baldurian and Elturian working-class populations against each other.
+- She salvaged a **Levy Exemption** for Fishmonger fleets in a backroom deal with the Consortium — guaranteed-low prices on fish to Consortium mess halls in exchange for skipping the Harbor Dredging Levy.
+- Her **goodwill kitchen** for the Free Traders' Basilisk Gate blockade — daily salted-fish shipments at cost — was sabotaged by an unknown rival, with poisoned stew putting dozens of blockaders in sickbeds and shattering the budding alliance.
+
+She remains hostile to the **Umberleen Unveiling** cult and tax-skirmishes with the [Flaming Fist](../../flaming-fist/summary.md). Her partnership with the [Chionthar Consortium](../../chionthar-consortium/summary.md) is professional, not warm.
+
+## See also
+
+- [Worshipful Company of Fishmongers](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-fishmongers/summary.md
+++ b/20-Factions/wc-fishmongers/summary.md
@@ -5,14 +5,31 @@ description: Ancient guild controlling Gray Harbour fishing fleets; food supply 
 
 # Worshipful Company of Fishmongers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+One of Baldur's Gate's oldest Worshipful Companies. Their power comes not from glamour but from sheer necessity: by controlling the fishing fleets of Gray Harbour, they control the primary protein source for the working class — tens of thousands of mouths whose loyalty translates directly into political weight. Led by [Matron Marga Saltwind](people/marga-saltwind.md).
 
 ## Ideology
 
+To preserve the Company's lock on the city's fisheries and the loyalty of the dockworkers and sailors who depend on it. The Fishmongers see themselves as "the blood of old Baldur's Gate" — older than the patriars, older than the walls, and entitled to the deference that age implies.
+
 ## Membership
+
+The captains of the fishing fleets and the owners of the dockside processing houses. Below them sit the unionized dockworkers and gutting-shed crews who do the actual work, organized through the standard Master / Wardens / Court of Assistants framework. Saltwind herself is a tough, no-nonsense matriarch and the kind of leader nobody attempts to charm.
 
 ## Methods
 
+- Sets the price of fish across the city's markets.
+- Controls the best berths in Gray Harbour and the unionized dockworker labor pool, used in cooperation with [the Guild](../guild/summary.md) to influence harbor traffic.
+- **Recently organized a dockworker strike** to extract concessions on harbor taxes, which collapsed in hours: the [Chionthar Consortium](../chionthar-consortium/summary.md) had pre-hired non-union strikebreakers from New Elturel refugees, protected by Consortium guards. The strike's failure has bred bitter resentment between Baldurian dockworkers and Elturian refugees.
+- Saltwind salvaged something by negotiating a **backroom Levy Exemption** with the Consortium: Fishmonger fleets dodge the Harbor Dredging Levy in exchange for guaranteed-low fish prices to Consortium mess halls.
+- A separate goodwill campaign — daily salted-fish shipments at cost to the Free Traders' Basilisk Gate blockade — was sabotaged by an unidentified rival who poisoned a stew cauldron, putting dozens of blockaders in sickbeds and torching the budding alliance.
+
 ## Hooks and Relationships
 
+**Allies.** [The Guild](../guild/summary.md) (dockworker labor coordination); a now-fragile working relationship with [the Free Traders of the Outskirts](../free-traders-of-the-outskirts/summary.md).
+
+**Enemies.** Frequent conflict with the **Umberleen Unveiling** cult, which Saltwind treats as dangerous fanatics. Tax friction with the [Flaming Fist](../flaming-fist/summary.md) over harbor levies. The [Chionthar Consortium](../chionthar-consortium/summary.md) — formal partner now, but the strikebreaking move proved exactly how much the alliance can be trusted.
+
 ## See also
+
+- [Matron Marga Saltwind](people/marga-saltwind.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-goldsmiths-jewelers/README.md
+++ b/20-Factions/wc-goldsmiths-jewelers/README.md
@@ -5,3 +5,4 @@ Regulators of precious metals and gems; the city's unofficial mint and assay off
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: theronius-goldhand.

--- a/20-Factions/wc-goldsmiths-jewelers/people/README.md
+++ b/20-Factions/wc-goldsmiths-jewelers/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Goldsmiths & Jewelers — people
+
+Named figures.
+
+## Index
+
+- [theronius-goldhand.md](theronius-goldhand.md)

--- a/20-Factions/wc-goldsmiths-jewelers/people/theronius-goldhand.md
+++ b/20-Factions/wc-goldsmiths-jewelers/people/theronius-goldhand.md
@@ -1,0 +1,29 @@
+---
+name: theronius-goldhand
+description: Master of the Goldsmiths' Company; meticulous, stern, and the closest thing the city has to a mint.
+---
+
+# Master Theronius Goldhand
+
+Master of the [Worshipful Company of Goldsmiths & Jewelers](../summary.md). The man whose seal is, in practice, what makes Baldurian coin trustworthy.
+
+## Manifesto
+
+> Coin is a promise. A gem is a memory. Gold is permanence. In a city of liars and thieves, we are the keepers of true value. Every transaction, from the smallest copper to the largest patriar loan, is built on the trust our seal provides. We do not just weigh metal; we weigh the city's faith in itself.
+
+## Role
+
+Goldhand spent the post-crisis decade making the Goldsmiths' assay offices the only assay offices that anyone actually believes. He works in close concert with the [Amnian Kontor](../../amnian-kontor/summary.md) and the city's major banks, and the relationship is symbiotic to the point of being structural — Athar's letters of credit are credible *because* Goldhand's assay is credible.
+
+His current operations:
+
+- A **patriar canary commission** for [Lord Durinbold](../../peerage-of-blood/summary.md) — a gold-and-silver automaton — ties the guild publicly to the [Peerage of Blood](../../peerage-of-blood/summary.md).
+- Recently exposed a small-time counterfeit operation in the Undercellar by handing the counterfeiter to [the Guild](../../guild/summary.md); the Guild keeps the body, the Goldsmiths keep the seal's reputation.
+- After failing to trace a suspicious wealth windfall through legitimate channels, he placed a discreet, high-paying bounty through the criminal underworld for any fence with information.
+
+He is allergic to scandal in a way that makes him predictable: any time the seal's credibility is challenged, he over-reacts. Adventurers who suddenly come into money will find his attention difficult to shake.
+
+## See also
+
+- [Worshipful Company of Goldsmiths & Jewelers](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-goldsmiths-jewelers/summary.md
+++ b/20-Factions/wc-goldsmiths-jewelers/summary.md
@@ -5,14 +5,31 @@ description: Regulators of precious metals and gems; the city's unofficial mint 
 
 # Worshipful Company of Goldsmiths & Jewelers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that decides what coin is worth in Baldur's Gate. In a city flooded with foreign currencies and reliant on stable markets, the Goldsmiths' assay seal is the closest thing to a standard. Their vaults hold a substantial fraction of the city's private wealth. Led by [Master Theronius Goldhand](people/theronius-goldhand.md).
 
 ## Ideology
 
+To be the incorruptible arbiters of value. The Company sees its credibility as the foundation of post-crisis commerce — every patriar loan, every Kontor letter of credit, every market trade depends on faith in their seal.
+
 ## Membership
+
+The most respected dwarven and human jewelers, minters, and bankers in the city. The Master / Wardens / Court of Assistants framework is unusually conservative here; reputation is the asset, and discipline of members is severe. Goldhand himself is meticulous, stern, and deeply allergic to scandal.
 
 ## Methods
 
+- Operates the only legally sanctioned assay offices in Baldur's Gate; certifies the purity of every gold and silver bar moving through the city.
+- Close ties to the [Amnian Kontor](../amnian-kontor/summary.md) and the city's major banks; effectively functions as the unofficial mint.
+- Quiet cooperation with [the Guild](../guild/summary.md) on counterfeit and laundering cases — Goldhand's agents handed a small-time Undercellar counterfeiter to the Guild in exchange for the Guild policing forgeries against the Goldsmiths' seal.
+- A standing **patriar canary commission**: Goldhand personally oversaw the creation of a magnificent gold-and-silver canary automaton for **Lord Durinbold**, cementing the guild's alliance with the [Peerage of Blood](../peerage-of-blood/summary.md).
+- When official channels fail to trace suspicious wealth — for instance, the source of a recent windfall on a particular adventuring party's books — Goldhand puts a quiet, high-paying bounty out through the criminal underworld for any fence willing to talk.
+
 ## Hooks and Relationships
 
+**Allies.** [Amnian Kontor](../amnian-kontor/summary.md), city banks, [Peerage of Blood](../peerage-of-blood/summary.md) traditionalists (via the Durinbold canary commission), and a transactional working relationship with [the Guild](../guild/summary.md) against shared counterfeit threats.
+
+**Enemies.** Counterfeiters and gilded-fake fences (often Guild-adjacent operators acting outside the truce); the [Takers of the Tithe](../takers-of-the-tithe/summary.md), who recently abandoned a hunt on a master jeweler after their Spotter ran into the guild's bodyguard cordon.
+
 ## See also
+
+- [Master Theronius Goldhand](people/theronius-goldhand.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-masons-sculptors/README.md
+++ b/20-Factions/wc-masons-sculptors/README.md
@@ -5,3 +5,4 @@ Wealthy guild that rebuilt Baldur's Gate post-crisis; near-monopoly on construct
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: borin-stonehand.

--- a/20-Factions/wc-masons-sculptors/people/README.md
+++ b/20-Factions/wc-masons-sculptors/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Masons & Sculptors — people
+
+Named figures.
+
+## Index
+
+- [borin-stonehand.md](borin-stonehand.md)

--- a/20-Factions/wc-masons-sculptors/people/borin-stonehand.md
+++ b/20-Factions/wc-masons-sculptors/people/borin-stonehand.md
@@ -1,0 +1,27 @@
+---
+name: borin-stonehand
+description: Master of the Masons' Company; the man who rebuilt Baldur's Gate, now defending the cracks in his own work.
+---
+
+# Master Borin Stonehand
+
+Master of the [Worshipful Company of Masons & Sculptors](../summary.md) and one of the men who put Baldur's Gate back together stone by stone after the Absolute Crisis. He has not forgotten that, and neither, in his telling, should anyone else.
+
+## Manifesto
+
+> When this city fell, who answered the call? Not the politicians, not the bankers. It was the Masons. We raised these walls from the rubble. Every stone in the new Heapside, every pillar in the High Hall, every cobblestone beneath your feet is a testament to our strength. This city does not stand on the whims of Dukes; it stands on the foundations we lay. We are the architects of this city's resilience, and we will not be forgotten.
+
+## Role
+
+Stonehand built his power during the Decade of Reconstruction, when the Council of Four would sign almost any contract that promised walls back up by winter. He used those years to consolidate quarries, train a deep bench of journeymen, and lobby zoning rules into shapes only his Company could profitably build under.
+
+His current crisis is the **Basilisk Gate wall section** — shoddy, cost-cutting work that cracked under its own weight. He paid off a [Flaming Fist](../../flaming-fist/summary.md) inspector, ran a cosmetic patch overnight, and tried to blame [Zhentarim](../../zhentarim/summary.md) saboteurs through [Baldur's Mouth](../../baldurs-mouth/summary.md). Public opinion did not buy it.
+
+A separate offer to discount contract pricing in exchange for political favor was scornfully and publicly rejected by **Archduke Silvershield**, who refused to let the city's safety be a bargaining chip. The embarrassment has driven Stonehand inward: an informant network now hunts dissenting masons inside his own guild, and the recent expulsions are the loudest signal yet that he intends to outlive this scandal by squeezing the Company harder.
+
+He is bitterly opposed to the [Circle of the Inner Grove](../../circle-of-the-inner-grove/summary.md), whose campaign against quarrying he treats as a personal attack.
+
+## See also
+
+- [Worshipful Company of Masons & Sculptors](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-masons-sculptors/summary.md
+++ b/20-Factions/wc-masons-sculptors/summary.md
@@ -5,14 +5,28 @@ description: Wealthy guild that rebuilt Baldur's Gate post-crisis; near-monopoly
 
 # Worshipful Company of Masons & Sculptors
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that literally rebuilt Baldur's Gate after the Absolute Crisis. The sheer scale of post-crisis contracts vaulted the Masons from a respectable trade guild into one of the wealthiest and most politically wired institutions in the city. Led by [Master Borin Stonehand](people/borin-stonehand.md).
 
 ## Ideology
 
+Every stone laid in Baldur's Gate should be laid by — and paid through — the Masons' Company. They cast themselves as the true builders of the new city, and treat any unlicensed construction as both an insult and a tax-evasion problem.
+
 ## Membership
+
+The city's finest stonemasons, architects, and sculptors, organized along the standard Worshipful framework: Master, two Wardens, a Court of Assistants, and a body of journeymen and seven-year apprentices. The Court has grown unusually paranoid under Stonehand, who survived the reconstruction years by being decisive and is increasingly extending those reflexes to internal politics.
 
 ## Methods
 
+- Uses Peerage of Coin seats to shape zoning, building codes, and inspection regimes in the Company's favor.
+- Aggressive Guild Wardens shut down — sometimes violently — any unsealed construction.
+- Quietly cuts corners on its own contracts: a recently-built wall section near the Basilisk Gate showed cracks from cost-cutting work, and Stonehand's inner circle paid off the Flaming Fist inspector and ran a hasty cosmetic repair in the dead of night to bury it.
+- Spins exposure as enemy action: when caught, Stonehand publicly blamed Zhentarim sabotage — a story [Baldur's Mouth](../baldurs-mouth/summary.md) printed but framed dubiously, denting the guild's credibility.
+
 ## Hooks and Relationships
 
+**Enemies.** Bitter rivalry with the [Circle of the Inner Grove](../circle-of-the-inner-grove/summary.md), whose druids treat Masons' quarrying as ecological terrorism. Reflexively hostile to the [Zhentarim](../zhentarim/summary.md), now doubly so since they were chosen as the public scapegoat for the Basilisk Gate cover-up. The [Western Gate Trading Company](../western-gate-trading-company/summary.md) and the [Council of Four](../council-of-four/summary.md) increasingly resent guild attempts to leverage city-safety contracts for political favors. Internal dissent has produced a faction of journeymen now leaking information about the cover-up; Stonehand's loyalists have already begun expelling the disloyal.
+
 ## See also
+
+- [Master Borin Stonehand](people/borin-stonehand.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-mercers-clothiers/README.md
+++ b/20-Factions/wc-mercers-clothiers/README.md
@@ -5,3 +5,4 @@ Arbiters of fashion and status; fine clothing for the city's elite.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: elethra-vance.

--- a/20-Factions/wc-mercers-clothiers/people/README.md
+++ b/20-Factions/wc-mercers-clothiers/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Mercers & Clothiers — people
+
+Named figures.
+
+## Index
+
+- [elethra-vance.md](elethra-vance.md)

--- a/20-Factions/wc-mercers-clothiers/people/elethra-vance.md
+++ b/20-Factions/wc-mercers-clothiers/people/elethra-vance.md
@@ -1,0 +1,30 @@
+---
+name: elethra-vance
+description: Master of the Mercers' Company; sells appearance as power, gossip as currency.
+---
+
+# Mistress Elethra Vance
+
+Master of the [Worshipful Company of Mercers & Clothiers](../summary.md). Impeccably dressed, politically savvy, and quietly the best-informed person in any patriar drawing room.
+
+## Manifesto
+
+> A man is not judged by his words, but by the cut of his coat. We do not merely sell fabric and thread; we sell ambition, status, and the appearance of power. The patriar who seeks a ducal seat, the merchant who seeks a lucrative contract — they come to us first. We are the silent partners in every negotiation, for we dress the players for their part.
+
+## Role
+
+Vance built the modern Mercers' Company on the post-crisis flood of new wealth. The plutocrats wanted to *look* like patriars; her tailors made it possible, and her seal made it credible. Today the guild controls the high-end clothing market and uses its access to the city's elite as a parallel intelligence service.
+
+Her current operations:
+
+- Locked an **exclusive Waterdhavian silk** import contract for the patriar winter festival, denying every rival access to the season's most-wanted fabric.
+- Tripled the price of black silks and velvets to capitalize on a string of high-profile deaths — "the business of grief."
+- Designed [Flaming Fist](../../flaming-fist/summary.md) dress uniforms whose details quietly signal alignment with the [Peerage of Blood](../../peerage-of-blood/summary.md), a political statement aimed at the traditionalist bloc.
+- Identified and quietly fired a journeyman tailor who was selling design sketches to a Bloomridge rival; he is now blacklisted from the trade.
+
+She is locked in a leather rivalry with [Goodman Borlu](../../wc-butchers-tanners/people/borlu.md) of the Butchers' Company, who insists fine hides belong to *his* guild's trade.
+
+## See also
+
+- [Worshipful Company of Mercers & Clothiers](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-mercers-clothiers/summary.md
+++ b/20-Factions/wc-mercers-clothiers/summary.md
@@ -5,14 +5,31 @@ description: Arbiters of fashion and status; fine clothing for the city's elite.
 
 # Worshipful Company of Mercers & Clothiers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that dresses Baldur's Gate's elite — and, in dressing them, decides who looks the part of power. The post-crisis surge of new plutocrat money made the Mercers indispensable: a Vance seal on a coat is, in practical terms, a credit reference. Led by [Mistress Elethra Vance](people/elethra-vance.md).
 
 ## Ideology
 
+To control the high-end clothing market and, through it, the visual language of status in Baldur's Gate. Appearance is power; the Company sells both.
+
 ## Membership
+
+The city's finest tailors, weavers, and dyers. Vance keeps an internal-security arm sharp enough to catch a single journeyman selling design sketches to a rival boutique — recently exercised when one was quietly fired and blacklisted from the trade. Below her sits the standard Master / Wardens / Court of Assistants framework.
 
 ## Methods
 
+- Buys raw textiles from the [Waterdhavian](../waterdhavian-kontor/summary.md) and [Amnian](../amnian-kontor/summary.md) Kontors and converts them into the gowns and coats demanded by the patriar class.
+- Sets the trends at patriar galas, then sells access to those trend-rooms as an information product — gossip from a fitting room is currency.
+- Recently locked the [Waterdhavian Kontor](../waterdhavian-kontor/summary.md) into an exclusive silk import contract, monopolizing the most-coveted material for the patriar winter festival.
+- Capitalized on a wave of high-profile deaths by tripling prices on black silks and velvets ("the business of grief").
+- Designed new [Flaming Fist](../flaming-fist/summary.md) dress uniforms with subtle [Peerage of Blood](../peerage-of-blood/summary.md) symbology baked in — a quiet political statement of allegiance.
+
 ## Hooks and Relationships
 
+**Allies.** [Waterdhavian Kontor](../waterdhavian-kontor/summary.md) and [Amnian Kontor](../amnian-kontor/summary.md) (raw textiles); [Peerage of Blood](../peerage-of-blood/summary.md) traditionalists, increasingly courted through symbolic design choices.
+
+**Enemies.** A fierce leather rivalry with the [Worshipful Company of Butchers & Tanners](../wc-butchers-tanners/summary.md) over which guild gets to use fine hides in fashion. Outer City independent artisans who undercut the Mercers' prices live in constant fear of Wardens turning up with confiscation orders.
+
 ## See also
+
+- [Mistress Elethra Vance](people/elethra-vance.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-shipwrights-calkers/README.md
+++ b/20-Factions/wc-shipwrights-calkers/README.md
@@ -5,3 +5,4 @@ Most powerful guild, controlling the city's vital shipbuilding and repair indust
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: helma-tallowshand.

--- a/20-Factions/wc-shipwrights-calkers/people/README.md
+++ b/20-Factions/wc-shipwrights-calkers/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Shipwrights & Calkers — people
+
+Named figures.
+
+## Index
+
+- [helma-tallowshand.md](helma-tallowshand.md)

--- a/20-Factions/wc-shipwrights-calkers/people/helma-tallowshand.md
+++ b/20-Factions/wc-shipwrights-calkers/people/helma-tallowshand.md
@@ -1,0 +1,25 @@
+---
+name: helma-tallowshand
+description: Master of the Shipwrights' Company; can bring Gray Harbour to a standstill with a single order.
+---
+
+# Master Helma Tallowshand
+
+Master of the [Worshipful Company of Shipwrights & Calkers](../summary.md) and arguably the single most economically powerful person in Baldur's Gate after the foreign Consuls. Her word governs every legal hull launched from Gray Harbour.
+
+## Manifesto
+
+> Look out at the Gray Harbour. Every mast that catches the wind, every hull that repels the waves, every keel that cuts the Chionthar — that is our work. The Kontors bring the coin, the Fist guards the walls, but it is our hands, our sweat, and our timber that make this city a gate and not a backwater. We do not just build ships; we build this city's future, one plank at a time.
+
+## Role
+
+Tallowshand rose through the docks during the Decade of Reconstruction, when the city was desperate for hulls and willing to pay anything for them. She used that decade to consolidate every drydock, lock down the finest timber routes, and seat enough Wardens in the [Peerage of Coin](../../peerage-of-coin/summary.md) to make her Company's preferences legislative.
+
+Her current play uses the **Harbor Dredging Levy** as a wedge: any vessel without the Shipwrights' seal is refused service at her drydocks, framed as a public-safety measure. Independent captains either join the Company or watch their ships rot. When the [Chionthar Consortium](../../chionthar-consortium/summary.md) and [Sembian Kontor](../../sembian-kontor/summary.md) collude to undercut her docking fees, she answers in kind — a "malfunctioning" loading crane on Consortium docks is already on her ledger.
+
+She is acutely aware that the [Guild](../../guild/summary.md)'s [River-Rats](../../river-rats/summary.md) treat her monopoly as an irrelevance, and that the Sembian logistics arm would happily strangle her if it could. She is patient with both, but not forgiving.
+
+## See also
+
+- [Worshipful Company of Shipwrights & Calkers](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-shipwrights-calkers/summary.md
+++ b/20-Factions/wc-shipwrights-calkers/summary.md
@@ -5,14 +5,29 @@ description: Most powerful guild, controlling the city's vital shipbuilding and 
 
 # Worshipful Company of Shipwrights & Calkers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The most powerful Worshipful Company in Baldur's Gate, holding a near-total monopoly on shipbuilding and repair across Gray Harbour. The Decade of Reconstruction made them indispensable: rebuilding the merchant fleet and naval capacity transformed an old trade guild into a political heavyweight. Led by [Master Helma Tallowshand](people/helma-tallowshand.md).
 
 ## Ideology
 
+Total control of every keel cut, plank fitted, and hull recaulked within the city's jurisdiction. The Company's self-image is that of "the bedrock of commerce" — without their work, no Kontor cargo moves and no Fist warship sails.
+
 ## Membership
+
+Master shipbuilders, skilled journeymen, and apprentices serving the standard seven-year term. The hierarchy follows the Worshipful framework — Master, two Wardens, a Court of Assistants drawn from senior masters — with rough-handed Guild Wardens enforcing the charter on the docks. Tallowshand commands enough leverage that a single order can bring the harbor to a standstill.
 
 ## Methods
 
+- Enforces the chartered monopoly through Guild Wardens who patrol drydocks and impound non-sealed vessels.
+- Controls the finest timber imports and every legal drydock berth.
+- Holds heavily-weighted seats in the [Peerage of Coin](../peerage-of-coin/summary.md) to shape maritime legislation.
+- Currently using the new **Harbor Dredging Levy** as cover to refuse repairs on any vessel without a Shipwrights' seal — a soft press to either join or ruin independent captains.
+- When pushed, retaliates directly: agents have already sabotaged a Chionthar Consortium loading crane in revenge for undercut docking fees.
+
 ## Hooks and Relationships
 
+**Enemies.** Constant friction with [the Guild](../guild/summary.md) and its [River-Rats](../river-rats/summary.md) smuggling crew, who run unregistered vessels through their docks. Fierce logistics rivalry with the [Sembian Kontor](../sembian-kontor/summary.md) over freight contracts, and now active sabotage trading with the [Chionthar Consortium](../chionthar-consortium/summary.md). A botched raid on a guildless drydock backed by the [Free Traders of the Outskirts](../free-traders-of-the-outskirts/summary.md) left a Warden taken hostage and the conflict dangerously public.
+
 ## See also
+
+- [Master Helma Tallowshand](people/helma-tallowshand.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Worshipful Companies); `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-smiths-armorers/README.md
+++ b/20-Factions/wc-smiths-armorers/README.md
@@ -5,3 +5,4 @@ Guild forging arms and armor for the city's guards, soldiers, and adventurers.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: tor-keg-silverhand.

--- a/20-Factions/wc-smiths-armorers/people/README.md
+++ b/20-Factions/wc-smiths-armorers/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Smiths & Armorers — people
+
+Named figures.
+
+## Index
+
+- [tor-keg-silverhand.md](tor-keg-silverhand.md)

--- a/20-Factions/wc-smiths-armorers/people/tor-keg-silverhand.md
+++ b/20-Factions/wc-smiths-armorers/people/tor-keg-silverhand.md
@@ -1,0 +1,27 @@
+---
+name: tor-keg-silverhand
+description: Master of the Smiths' Company; conservative dwarven smith caught between Lantaner espionage and Dammon's infernal experiments.
+---
+
+# Master Tor-keg Silverhand
+
+Master of the [Worshipful Company of Smiths & Armorers](../summary.md). A conservative dwarf with a deep respect for tradition and an uneasy awareness that tradition alone will not keep the Company ahead of the [Lantaner Concession](../../lantaner-concession/summary.md).
+
+## Manifesto
+
+> Peace is a lie told between wars. Strength is not found in laws or coin, but in the shield that turns a blade and the sword that holds the line. We are the heart of this city's strength. We arm the Fist that guards the walls and the adventurer that clears the sewers. In every battle, won or lost, our steel is there. We forge the tools of survival.
+
+## Role
+
+Tor-keg runs the Company on classical dwarven Worshipful lines: long apprenticeships, rigorous masterpiece reviews, conservative pricing, and lucrative state contracts with the [Flaming Fist](../../flaming-fist/summary.md). His current crisis is not internal but supply-chain: the **Basilisk Gate blockade** is choking his forges' iron supply. He has personally petitioned **Marshal Valerius Flint** at Wyrm's Rock, soldier-to-soldier, to find a political opening.
+
+His harder problem is that the Company's most famous member is barely a member at all. **Dammon at the Forge of the Nine** runs his own infernal-iron salvage program, has put out a public call for Hell-damaged armor from the Fall of Elturel, and is privately hunting a New Elturel **infernal-contract shard** to weave into his forge-work. Tor-keg neither approves nor controls Dammon, and the Court of Assistants is split on whether to discipline him.
+
+A separate gambit — an "astral bargain" approach to the [Unchained](../../unchained/summary.md) for githyanki forging knowledge — was scornfully dismissed by **Commander K'laar**. The githyanki now view the guild's craft as crude.
+
+He is locked in industrial-espionage cold war with the [Lantaner Concession](../../lantaner-concession/summary.md); the recent partial smokepowder schematic, smuggled out by a Lantaner apprentice spy who fled to his handlers, is sitting on his Court's table.
+
+## See also
+
+- [Worshipful Company of Smiths & Armorers](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-smiths-armorers/summary.md
+++ b/20-Factions/wc-smiths-armorers/summary.md
@@ -5,14 +5,31 @@ description: Guild forging arms and armor for the city's guards, soldiers, and a
 
 # Worshipful Company of Smiths & Armorers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that arms Baldur's Gate. With constant demand from the [Flaming Fist](../flaming-fist/summary.md), Kontor Guards, Guild Wardens, and the post-crisis adventurer surge, the Smiths have become wealthier and more vital than at any point in living memory. Led by [Master Tor-keg Silverhand](people/tor-keg-silverhand.md), with the famed infernal mechanic **Dammon** at the **Forge of the Nine** as the guild's most prominent — and most unmanageable — independent member.
 
 ## Ideology
 
+To be the premier crafters of arms and armor on the Sword Coast: tradition first, innovation second, but a constant willingness to acquire useful new techniques by purchase, alliance, or theft.
+
 ## Membership
+
+The city's best blacksmiths and armorers, organized under the standard Master / Wardens / Court of Assistants framework. Tor-keg keeps the Court conservative, but the membership includes restless innovators — Dammon foremost — who pull the guild's interests into uncomfortable territory like infernal-iron salvage.
 
 ## Methods
 
+- Controls the city's forges and regulates the sale of all high-quality arms and armor; lucrative state contracts with the Flaming Fist anchor the guild's revenue.
+- The guild seal is a legal requirement on masterwork-grade arms.
+- **Currently petitioning the deadlocked Parliament** for relief: Tor-keg personally visited Marshal Flint at Wyrm's Rock, appealing to him soldier-to-soldier to break the Basilisk Gate blockade that is starving his forges of iron.
+- **Dammon at the Forge of the Nine** is running his own program: a public call to adventurers for any **infernal-iron salvage** from the Fall of Elturel, paid at premium, plus a separate private hunt for a New Elturel **infernal-contract shard** physically manifested during the Fall.
+- An attempted approach to the [Unchained](../unchained/summary.md) for an "astral bargain" — to acquire githyanki forging knowledge — was contemptuously rejected by Commander K'laar, leaving the Company viewed with disdain by the githyanki.
+
 ## Hooks and Relationships
 
+**Allies.** Lucrative supply contracts with the [Flaming Fist](../flaming-fist/summary.md); cordial dealings with the [Peerage of Blood](../peerage-of-blood/summary.md) traditionalist patriarchs.
+
+**Enemies.** Active industrial-espionage cold war with the [Lantaner Concession](../lantaner-concession/summary.md) over smokepowder secrets — a Lantaner apprentice spy was recently nearly caught inside the Cogwork Quay; a partial schematic of the smokepowder mechanism is now in Smiths' hands. Direct competition with independent smiths like the **Stormshore Armoury**. Hostile reception from the [Unchained](../unchained/summary.md) after Tor-keg's astral-bargain misstep.
+
 ## See also
+
+- [Master Tor-keg Silverhand](people/tor-keg-silverhand.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-sorcerous-sodality/README.md
+++ b/20-Factions/wc-sorcerous-sodality/README.md
@@ -5,3 +5,4 @@ Reformed Sorcerous Sundries; regulates magical goods and licenses public spellca
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: lorroakan.

--- a/20-Factions/wc-sorcerous-sodality/people/README.md
+++ b/20-Factions/wc-sorcerous-sodality/people/README.md
@@ -1,0 +1,7 @@
+# Sorcerous Sodality — people
+
+Named figures.
+
+## Index
+
+- [lorroakan.md](lorroakan.md)

--- a/20-Factions/wc-sorcerous-sodality/people/lorroakan.md
+++ b/20-Factions/wc-sorcerous-sodality/people/lorroakan.md
@@ -1,0 +1,29 @@
+---
+name: lorroakan
+description: Master of the Sorcerous Sodality; licenses every legal spellcaster in the city and treats unlicensed magic as a civic emergency.
+---
+
+# Master Lorroakan
+
+Master of the [Sorcerous Sodality](../summary.md) (or his current successor), operating from the tower of **Sorcerous Sundries**. He holds the charter granted in the wake of the Absolute Crisis to license every public spellcaster operating in Baldur's Gate.
+
+## Manifesto
+
+> Magic is not a toy. It is a fire that can warm a city or burn it to ash. The unworthy and the untrained will not be allowed to play with it. We are the arbiters of the arcane. We determine who is fit to wield this power. We license, we regulate, we control. For a world without magical order is a world of pure chaos, and we are the wall that holds that chaos back.
+
+## Role
+
+The Sodality's charter was a direct response to the Absolute Crisis — a civic decision that uncontrolled magic was an unacceptable risk and that someone with the authority to license, raid, and confiscate had to exist. Lorroakan accepted that someone would be him, and runs the Company as a regulator of last resort.
+
+His current operations:
+
+- **Routine licensing raids** clear out hedge wizards and unlicensed shops; a Bloomridge raid recently confiscated a "love-potion peddler"'s spellbook with a heavy fine.
+- An **active investigation** into powerful unlicensed magic at a ruined watchtower has produced an open case file on the fugitive mage **Zora**. The arcane trail dissipated near the Phoenix Pits in New Elturel; Lorroakan responded by installing **permanent scrying censers** at Wyrm's Crossing and the Basilisk Gate to catch significant arcane activity at the checkpoints.
+- A **scrying ritual on Lord Corin Durinbold** of the [Peerage of Blood](../../peerage-of-blood/summary.md) is in progress, intended to produce political leverage against the traditionalist bloc. If exposed, the operation would create a major scandal; Lorroakan has decided the parliamentary stakes justify the risk.
+
+He keeps the **Sorcerous Vault** beneath his tower closely guarded, and is openly suspicious of every warlock-pact arrangement in the city — including the one binding [the Unveiled](../../unveiled/summary.md).
+
+## See also
+
+- [Sorcerous Sodality](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-sorcerous-sodality/summary.md
+++ b/20-Factions/wc-sorcerous-sodality/summary.md
@@ -5,14 +5,29 @@ description: Reformed Sorcerous Sundries; regulates magical goods and licenses p
 
 # Sorcerous Sodality *(aka Sorcerous Sundries)*
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The reformed Sorcerous Sundries — granted a new charter as a Worshipful Company in the wake of the Absolute Crisis to regulate the sale of magical goods and license every public spellcaster operating in Baldur's Gate. Where the Crisis exposed uncontrolled magic as a civic threat, the Sodality is the city's answer: a guild with the power to permit, fine, raid, and arrest. Led by [Master Lorroakan](people/lorroakan.md) (or his current successor) from the tower of Sorcerous Sundries.
 
 ## Ideology
 
+To control and regulate all public use of magic within the city. The Sodality holds — with absolute conviction — that uncontrolled magic is the single greatest danger Baldur's Gate has ever faced and that licensing is the only thing standing between the city and another Crisis.
+
 ## Membership
+
+The most powerful and politically connected wizards and sorcerers in the city. The standard Worshipful Master / Wardens / Court of Assistants framework, augmented by an enforcement arm of **Sodality Investigators** with raid authority. The Master operates from the tower of **Sorcerous Sundries**, and the **Sorcerous Vault** beneath it holds powerful secrets the Court guards jealously.
 
 ## Methods
 
+- Issues licenses to spellcasters-for-hire at hefty fees; unlicensed casting is a serious crime.
+- Controls the legal sale of most magical scrolls and components.
+- Routine **raids on unlicensed casters**: a recent operation seized the spellbook and components of a Bloomridge "hedge wizard" peddling charms and love potions, with a heavy fine and stern warning.
+- **Active investigation** of powerful, unlicensed magic detected at a ruined watchtower: a case file is open, and Sodality Investigators have been chasing the arcane trail of a fugitive mage named **Zora**. The trail went cold near the Phoenix Pits in New Elturel; in response, the Sodality has installed permanent **scrying censers** at Wyrm's Crossing and the Basilisk Gate to alert them to significant arcane activity passing through the checkpoints.
+- Currently running a **scrying ritual on Lord Corin Durinbold** of the [Peerage of Blood](../peerage-of-blood/summary.md) to gain political leverage in Parliament — a dangerous escalation if exposed.
+
 ## Hooks and Relationships
 
+**Enemies.** Every unlicensed spellcaster, hedge wizard, and warlock-pact magic-user — including the [Unveiled](../unveiled/summary.md), various cult cells, and private practitioners. Particularly suspicious of warlock-pact magic in any form. The fugitive mage **Zora** is an active priority. The [Peerage of Blood](../peerage-of-blood/summary.md) — and especially Durinbold — should the scrying program ever leak.
+
 ## See also
+
+- [Master Lorroakan](people/lorroakan.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.

--- a/20-Factions/wc-vintners-brewers/README.md
+++ b/20-Factions/wc-vintners-brewers/README.md
@@ -5,3 +5,4 @@ Guild controlling alcohol trade from cheap ale to imported wine; key to social l
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: belba-quickfoot.

--- a/20-Factions/wc-vintners-brewers/people/README.md
+++ b/20-Factions/wc-vintners-brewers/people/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Vintners & Brewers — people
+
+Named figures.
+
+## Index
+
+- [belba-quickfoot.md](belba-quickfoot.md)

--- a/20-Factions/wc-vintners-brewers/people/belba-quickfoot.md
+++ b/20-Factions/wc-vintners-brewers/people/belba-quickfoot.md
@@ -1,0 +1,30 @@
+---
+name: belba-quickfoot
+description: Master of the Vintners' Company; halfling political operator who treats taverns as listening posts.
+---
+
+# Master Belba Quickfoot
+
+Master of the [Worshipful Company of Vintners & Brewers](../summary.md). A halfling, a shrewd politician, and the woman who decides — in practice — which taverns in Baldur's Gate are allowed to keep their doors open.
+
+## Manifesto
+
+> A deal is not struck, a friendship is not forged, a sorrow is not drowned without our say-so. We are the masters of fellowship and the brewers of courage. The nobles in their halls and the sailors in their cups all drink from our barrels. We do not sell wine and ale; we sell laughter, solace, and the lubrication for every transaction of power in this city.
+
+## Role
+
+Quickfoot consolidated the guild during the post-crisis tavern boom by treating every cask the way the [Amnian Kontor](../../amnian-kontor/summary.md) treats coin: as a unit of leverage. Every Vintners-licensed taproom is also a listening post, and her network of brewers and tavernkeepers feeds back gossip her Court of Assistants weaponizes weekly.
+
+Her current playbook:
+
+- A working alliance with [the Guild](../../guild/summary.md)'s Ward-Bosses keeps her product flowing in the Lower City and the [Flaming Fist](../../flaming-fist/summary.md) out of her warehouses.
+- Wardens recently raided an Eastway tenement still and made a brutal public example of the operator.
+- A "gift" of priceless Amnian wine — acquired from the Undercellar through unsubtle channels — bought a [Peerage of Coin](../../peerage-of-coin/summary.md) vote against a luxury tax.
+- Her overture to **Lord Durinbold** of the [Peerage of Blood](../../peerage-of-blood/summary.md) misfired badly: the ale was returned with a scathing note and the patriar bloc now treats her overtures as crass bribery. Quickfoot has redirected her courtship toward the **Archduke's new mercenary commander**, sending Calishite spirits and Waterdhavian wines instead.
+
+She is patient with smugglers she can co-opt and merciless with those she cannot.
+
+## See also
+
+- [Worshipful Company of Vintners & Brewers](../summary.md).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/wc-vintners-brewers/summary.md
+++ b/20-Factions/wc-vintners-brewers/summary.md
@@ -5,14 +5,32 @@ description: Guild controlling alcohol trade from cheap ale to imported wine; ke
 
 # Worshipful Company of Vintners & Brewers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The Worshipful Company that holds the keys to Baldur's Gate's social life — every tavern's tap, every patriar's wine cellar, every cask hauled out of a Kontor warehouse. As the city's population swelled, the guild consolidated production licensing and locked down distribution contracts on imported wines, profiting at every link in the chain. Led by [Master Belba Quickfoot](people/belba-quickfoot.md).
 
 ## Ideology
 
+A strict, profitable monopoly on every alcoholic beverage produced or sold inside the city. The Company casts itself as the lubricant of civic life: no deal is struck, no sorrow drowned, without a Vintners-stamped cup in hand.
+
 ## Membership
+
+Brewers, vintners, and the owners of the largest taverns. Quickfoot, a halfling and a shrewd political operator, leads from a guildhall whose Court of Assistants doubles as one of the city's most useful intelligence rooms — patrons drink, journeymen listen.
 
 ## Methods
 
+- Guild Wardens routinely inspect taverns to confiscate unlicensed product and fine the operators.
+- Sets prices on every legal cask in the city and lobbies fiercely against any reduction in liquor taxes.
+- Recently smashed a Lower City moonshine operation in Eastway — stills broken, casks confiscated, the operator made a public example.
+- Alliances with [Guild](../guild/summary.md) Ward-Bosses handle distribution in the Lower City, sidestepping the [Flaming Fist](../flaming-fist/summary.md).
+- Quickfoot has personally bribed at least one [Peerage of Coin](../peerage-of-coin/summary.md) member with priceless Amnian wine (acquired from the Undercellar) to kill a luxury-tax bill.
+- A clumsy attempt to court Lord Durinbold with "gift" ale was returned to the guildhall with a scathing public note; Quickfoot has since pivoted, sending Calishite spirits and Waterdhavian wines to the Archduke's new mercenary commander.
+
 ## Hooks and Relationships
 
+**Allies.** Tight working alignment with the [Guild](../guild/summary.md)'s Ward-Bosses for Lower City distribution.
+
+**Enemies.** Constant friction with [Guild](../guild/summary.md) smugglers (and [Wharf Rats](../wharf-rats/summary.md) / [River-Rats](../river-rats/summary.md)) who run untaxed spirits — the alliance is real but local. Tense with the [Amnian Kontor](../amnian-kontor/summary.md), which resents the markup on its imported wines. Burned bridges with the [Peerage of Blood](../peerage-of-blood/summary.md) traditionalists after the Durinbold incident.
+
 ## See also
+
+- [Master Belba Quickfoot](people/belba-quickfoot.md) — Master of the Company.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`; dossier ch. 8.


### PR DESCRIPTION
## Summary

- Replaces every `20-Factions/wc-*/summary.md` stub with full prose covering Ideology, Membership, Methods, Hooks and Relationships, and See also — each grounded in a current weekly action drawn from `faction-quests.xlsx`.
- Adds a leader page under `20-Factions/wc-*/people/` for each of the 12 Companies (manifesto block-quote + Role + back-links), and wires up the cross-references called out in issue #14 (Shipwrights ↔ Guild/Sembian, Masons ↔ Inner Grove/Zhentarim, Smiths ↔ Lantaner/Dammon, Sorcerous Sodality ↔ Unveiled/Durinbold scry, etc.).
- All files are under 500 words; `scaffold_factions.py` was re-run and produces no further diffs.

Closes #14.

## Test plan

- [ ] Skim the 12 summaries to confirm the new prose matches the campaign tone.
- [ ] Spot-check 2–3 leader pages for manifesto fidelity to source.
- [ ] Verify `uv run python src/ingest/scaffold_factions.py` is idempotent against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)