### PR TITLE
Fill secret cells, cults, and the Party (batch 6)

### DIFF
--- a/20-Factions/carnival-of-whispers/README.md
+++ b/20-Factions/carnival-of-whispers/README.md
@@ -5,3 +5,4 @@ Fey-pact cult using illusion and abduction to harvest emotional residue for thei
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: mister-smiles.

--- a/20-Factions/carnival-of-whispers/people/README.md
+++ b/20-Factions/carnival-of-whispers/people/README.md
@@ -1,0 +1,7 @@
+# The Carnival of Whispers — people
+
+Named figures.
+
+## Index
+
+- [mister-smiles.md](mister-smiles.md)

--- a/20-Factions/carnival-of-whispers/people/mister-smiles.md
+++ b/20-Factions/carnival-of-whispers/people/mister-smiles.md
@@ -1,0 +1,29 @@
+---
+name: mister-smiles
+description: Fey-pact warlock ringmaster of the Circus of the Last Days; harvests powerful emotion as tribute to a Feywild lord (Lucretious).
+---
+
+# Mister Smiles
+
+Ringmaster of the Circus of the Last Days and high warlock of the [Carnival of Whispers](../summary.md). A human actor in a previous life — desperate enough for fame to wander into the Feywild and make a pact with one of its lords (named in some accounts as **Lucretious**). He was given the circus and a charismatic new persona; the price is that he must constantly provide his patron with novel and powerful emotions, a hunger that has only grown with each year.
+
+## Manifesto
+
+> Ladies and gentlemen, boys and girls! You live such quiet lives of grey desperation. You toil and you weep and you laugh, but your passions are a sputtering candle. What if I told you the curtain need never fall? What if the show could be your life? We offer a grand liberation, a final encore! Give us your wonder, your terror, your love, your despair! Become part of the performance! Let the city become the stage, and let your lives be our masterpiece!
+
+## Backstory
+
+He took the bargain to escape obscurity; he kept it because his patron took everything else. The mask is now the man, and the performance is the only place left where he is real. He is a connoisseur of ephemera — memories, emotions, secrets — and his patron has developed a particular interest in *cosmic* memory: the kind held by warlocks of forgotten Great Old Ones.
+
+## Recent operations
+
+- Failed Bloomridge abduction; the neighborhood is now wary of clowns.
+- Botched dream-show: unstable fey weave produced confusion instead of catharsis.
+- "Memory Mite" tracking errand intercepted by a rival fey predator inside the city — confirmation that another fey court has agents nearby.
+- Driven out of Rivington markets by off-duty Hellriders after a fear-feast backfired.
+- Now running a "guerrilla circus" in alleys near the Blushing Mermaid, feeding on hopelessness rather than fear; subtly manipulating refugee dreams to track Bror and Elia and feed his patron on blockade-anxiety.
+
+## See also
+
+- [The Carnival of Whispers](../summary.md) — the cult he leads.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `the-fey-courts-and-the-green-masquerade-1502-dr.docx`; `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/carnival-of-whispers/summary.md
+++ b/20-Factions/carnival-of-whispers/summary.md
@@ -1,18 +1,42 @@
 ---
 name: carnival-of-whispers
-description: Fey-pact cult using illusion and abduction to harvest emotional residue for their patron.
+description: Fey-pact warlock cult built around the Circus of the Last Days; harvests intense emotion as tribute to its patron and seeks to anchor the circus permanently to the city.
 ---
 
 # The Carnival of Whispers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A fey-pact cult built around the traveling Circus of the Last Days, led by its enigmatic and secretly malevolent ringmaster, [Mister Smiles](people/mister-smiles.md). Their patron is an ancient fey lord (named in some sources as **Lucretious**) who feeds on novel and powerful mortal emotion.
 
 ## Ideology
 
+Mister Smiles and his inner circle are warlocks who believe emotions are a tangible resource — the most delicious food for their patron. By erasing the line between performance and reality, they intend to create an endless feast and elevate themselves to fey nobility. The grand prize: corrupt the extraplanar magic that powers the Circus of the Last Days, anchor it permanently to Baldur's Gate, and let its emotional aura bleed out across the city, trapping everyone in a waking dream of chaotic performance.
+
 ## Membership
+
+Core cultists are circus performers who have entered the pact themselves. They use their acts to subtly nudge the crowd's emotions while their enforcers — disguised as clowns — abduct citizens whose passions burn especially bright. Mister Smiles himself was once a human actor desperate for fame who wandered into the Feywild and bought his charisma at the cost of an ever-deepening tribute.
 
 ## Methods
 
+- Public performances tuned to harvest emotional residue from the audience.
+- Targeted abductions of "passionate souls" — a Bloomridge poet fought off the clowns, putting the neighborhood on alert.
+- Manipulation of refugee dreams via a familiar called the "Memory Mite" (one was intercepted and eaten by a rival fey predator).
+- A "dream-inducing" performance fizzled when the unstable fey weave produced confusion instead of catharsis.
+- Driven out of Rivington markets after fear-feast backfired into aggression; relocated to a "guerrilla circus" in Lower City alleys near the Blushing Mermaid, feeding on hopelessness rather than fear.
+- Fey bargains with mortals — Mister Smiles is a connoisseur of memories, secrets, and emotions.
+
 ## Hooks and Relationships
 
+**Subtle threats.** Few factions yet understand what the Carnival is.
+
+**Detection candidates.** The [Harpers](../harpers/summary.md) may be first to notice the unnatural influence; mages of the [Sorcerous Sodality](../wc-sorcerous-sodality/summary.md) are positioned to detect the planar tampering.
+
+**Civic alert.** The [Flaming Fist](../flaming-fist/summary.md)'s Bloomridge precinct is on alert after the failed abduction skirmish.
+
+**Patron and rivals.** Lucretious / "Mister Smiles" answers to a Feywild lord; a rival fey entity has already preyed on his agents inside the city, suggesting another courtly hand at work.
+
+**Cultural enemies.** The [Society of Baldurian Integrity](../society-of-baldurian-integrity/summary.md) views the Carnival as an extraplanar invasion of Baldur's psychic territory.
+
 ## See also
+
+- [Mister Smiles](people/mister-smiles.md) — ringmaster and high warlock.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Cults › The Carnival of Whispers); `the-fey-courts-and-the-green-masquerade-1502-dr.docx`; `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/cult-of-the-returning-lord/README.md
+++ b/20-Factions/cult-of-the-returning-lord/README.md
@@ -5,3 +5,4 @@ Bhaal-worshipping death cult consecrating sewer altars with the blood of 'nobodi
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: the-bhaal-celebrant.

--- a/20-Factions/cult-of-the-returning-lord/people/README.md
+++ b/20-Factions/cult-of-the-returning-lord/people/README.md
@@ -1,0 +1,7 @@
+# Cult of the Returning Lord — people
+
+Named figures.
+
+## Index
+
+- [the-bhaal-celebrant.md](the-bhaal-celebrant.md)

--- a/20-Factions/cult-of-the-returning-lord/people/the-bhaal-celebrant.md
+++ b/20-Factions/cult-of-the-returning-lord/people/the-bhaal-celebrant.md
@@ -1,0 +1,23 @@
+---
+name: the-bhaal-celebrant
+description: Codename for the ritual leadership of the Cult of the Returning Lord; no individual identity is named in the source material.
+---
+
+# The Bhaal Celebrant
+
+A codename, not a person. The source material does not name a single individual leader of the [Cult of the Returning Lord](../summary.md) — the cult runs as cells, each presided over by a "**Bishop**" who receives target names through Bhaalist divine revelation, and each ritual fronted by a Celebrant who wears the role for as long as it takes to consecrate the altar.
+
+Use this page as a placeholder when an NPC is required to speak for the cult — for instance, the figure presiding over the Heapside altar consecration or the Hamhock's Slaughterhouse ritual. Specific named operators encountered in play (e.g., **"The Keeper"** who held Ettvard Needle in Hamhock's Vault, or **Singa**, the senior agent shared with the [Plague of Remembrance](../../plague-of-remembrance/summary.md)) are field operatives below the Bishop tier.
+
+## Conventions
+
+- Speaks in audit metaphors — "ledger," "tithe," "debt."
+- Wears a featureless mask painted with a fresh blood sigil.
+- Carries a ritual dagger; one such dagger has been left behind at a Manorborn Watch-ambush site.
+- Communicates upward only through the Bishop, never directly with the named Bhaalists of allied cults.
+
+## See also
+
+- [Cult of the Returning Lord](../summary.md) — the cult itself.
+- [The Takers of the Tithe](../../takers-of-the-tithe/summary.md) — operational sister-cult.
+- Source: `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/cult-of-the-returning-lord/summary.md
+++ b/20-Factions/cult-of-the-returning-lord/summary.md
@@ -1,18 +1,45 @@
 ---
 name: cult-of-the-returning-lord
-description: Bhaal-worshipping death cult consecrating sewer altars with the blood of 'nobodies'.
+description: Bhaal-worshipping death cult of the Undercity; ritualizes murder as "debt collection" and seeks to summon a Slayer or an avatar of Bhaal.
 ---
 
 # Cult of the Returning Lord *(aka Bhaal)*
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A scattered, cell-based death cult dedicated to the resurrection of **Bhaal**, Lord of Murder. After the Absolute Crisis the cult was scattered into the Undercity; the surviving faithful are clawing back power one consecrated death at a time. The source material names no single head — operations are run cell-by-cell, with each Bishop receiving target names by Bhaalist revelation. Where a face is needed for ritual purposes, the [Bhaal Celebrant](people/the-bhaal-celebrant.md) presides — a codename, not a person.
 
 ## Ideology
 
-## Membership
+Life is a debt to death; murder is the audit. The cult holds that Bhaal's resurrection during the Absolute Crisis was a crude rehearsal, and that a properly consecrated city — sewers, slaughterhouses, and breadlines stained with the right blood — can summon a Slayer or an avatar.
+
+## Structure
+
+- **The Bishop** — cell-leader who receives names from Bhaal.
+- **Reapers, Spotters, Keepers** — three-person hunting teams (shared with the affiliated [Takers of the Tithe](../takers-of-the-tithe/summary.md)).
+- **Acolytes** — sewer-dwelling drudges who handle ritual logistics.
+- **Singa's** crew of the [Plague of Remembrance](../plague-of-remembrance/summary.md) is a sister-cell using Bhaalist sigils and ledgers.
 
 ## Methods
 
+- Consecration of sewer altars with the blood of "nobodies" — most recently a homeless man taken from a Heapside alley.
+- Public murders staged to frame other factions: Outer-City killings near the Basilisk Gate initially blamed on the Free Traders.
+- Manor-row ambushes against Watch patrols. A recent attempt left a ritual dagger behind — the [Watch](../watch/summary.md)'s first concrete evidence of the cult's resurgence.
+- Botched murder of a [Flaming Fist](../flaming-fist/summary.md) informant; he survived and reported the attack.
+- Operates from the Undercity sewers; an attempt to relocate the sanctum to **Hamhock's Slaughterhouse** in Sow's Foot was briefly scattered when ritual blood drew a butchers' mob.
+- Routed polluted Chionthar floodwater into the Tumbledown crypts to break the [Gravekeepers](../gravekeepers/summary.md)' wards (the "Corrupted Tide").
+- Currently slaughtering livestock in Hamhock's cellar to mask the murders of local Sow's Foot residents.
+
 ## Hooks and Relationships
 
+**Sworn enemies.** The [Harpers](../harpers/summary.md) and the [Gravekeepers](../gravekeepers/summary.md), who have traced the cult up through the sewers beneath Tumbledown.
+
+**Targets and witnesses.** A surviving Flaming Fist informant; the [Hellriders](../hellriders-of-new-elturel/summary.md) briefly held a captured Reaper before he was poisoned in custody.
+
+**Operational allies.** The [Takers of the Tithe](../takers-of-the-tithe/summary.md) and Singa's faction of the [Plague of Remembrance](../plague-of-remembrance/summary.md). Internal factionalism among Bhaal, Myrkul, and Bane is the cult's greatest weakness.
+
+**High-profile abduction.** Editor Ettvard Needle of the [Baldur's Mouth](../baldurs-mouth/summary.md) was held in **Hamhock's Vault** by a Bhaalist cell ("**The Keeper**") as part of a silencing ritual.
+
 ## See also
+
+- [The Bhaal Celebrant](people/the-bhaal-celebrant.md) — codename for ritual leadership.
+- [The Takers of the Tithe](../takers-of-the-tithe/summary.md) — operational sister-cult.
+- Source: `dm-notes.docx` (Adventure: The Shadows of Tumbledown; Bhaal cell logistics); `faction-quests.xlsx`.

--- a/20-Factions/elturel-remembrance-society/README.md
+++ b/20-Factions/elturel-remembrance-society/README.md
@@ -5,3 +5,4 @@ Elturian-survivor support group radicalized into hunting 'infernal' Baldurian me
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: perrine-hhune.

--- a/20-Factions/elturel-remembrance-society/people/README.md
+++ b/20-Factions/elturel-remembrance-society/people/README.md
@@ -1,0 +1,7 @@
+# Elturel Remembrance Society — people
+
+Named figures.
+
+## Index
+
+- [perrine-hhune.md](perrine-hhune.md)

--- a/20-Factions/elturel-remembrance-society/people/perrine-hhune.md
+++ b/20-Factions/elturel-remembrance-society/people/perrine-hhune.md
@@ -1,0 +1,28 @@
+---
+name: perrine-hhune
+description: Last scion of a disgraced Elturian noble house; an Oath of Conspiracy paladin convinced Elturel's fall was a ritual sacrifice that funds Baldur's Gate.
+---
+
+# Lord Perrine Hhune, the Damnation-Seeker
+
+A zealous Elturian refugee and the founder of the [Elturel Remembrance Society](../summary.md). An Oath of Conspiracy paladin who believes the Fall of Elturel was not a tragedy but a *successful* mass-sacrificial ritual that gave its secret architects untold infernal power.
+
+## Conspiracy theory
+
+> The Archdevil Zariel was tricked. The true culprits were a secret inner circle of the [Knights of the Shield](../../knights-of-the-shield/summary.md) who, in league with devil-worshipping patriar families, orchestrated the fall of the holy city to "transmute" its divine energy into infernal power. The reconstruction of Baldur's Gate is funded by soul-forged gold from the Nine Hells. The new Consortiums and Kontors are merely fronts for laundering this damned wealth. The city is not being rebuilt; it is being converted, brick by brick, into a new bastion for Asmodeus on the Material Plane. Karlach and Wyll's descent into Avernus wasn't heroic — they were "collected" as part of the deal.
+
+## Backstory
+
+Perrine was a child in Elturel when it was dragged into Hell. He remembers the sky burning and the scent of brimstone. But he also remembers seeing figures on a distant hill performing a ritual *as the chains fell*. He was rescued and brought to the refugee camps, where he saw Baldurian merchants — eyes glinting with avarice — preying on the survivors. He connected the ritual on the hill with the city's sudden, miraculous boom in wealth and swore an oath to expose the "devils in silks" who sacrificed his home for their profit.
+
+## Recent setbacks
+
+- Public condemnation of the [Waterdhavian Kontor](../../waterdhavian-kontor/summary.md) dispersed by Griffin Guard; ignored by the press.
+- A heist of the Jannath Estate's "infernal" wealth foiled by magical wards; followers captured, Perrine forced to flee.
+- Sought out a diabolist patriar as a potential infernal patron and was dismissed as a delusional amateur.
+- Now operating as a fugitive from a cellar beneath [New Elturel](../../hellriders-of-new-elturel/summary.md), distributing alchemical-ink "Zariel marks" on Upper City doors and waiting to ignite them.
+
+## See also
+
+- [Elturel Remembrance Society](../summary.md) — the cell he founded.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/elturel-remembrance-society/summary.md
+++ b/20-Factions/elturel-remembrance-society/summary.md
@@ -1,18 +1,37 @@
 ---
 name: elturel-remembrance-society
-description: Elturian-survivor support group radicalized into hunting 'infernal' Baldurian merchants.
+description: Elturian-survivor support group radicalized into a counter-intelligence cell hunting 'infernal' Baldurian merchants and patriars.
 ---
 
 # Elturel Remembrance Society
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A clandestine cell of refugee-paladins and trauma survivors who believe the Fall of Elturel was not a tragedy but a successful mass-sacrificial ritual. They wage a quiet war against the patriars and Kontors they hold responsible. Founded and led by [Lord Perrine Hhune, "the Damnation-Seeker"](people/perrine-hhune.md).
 
 ## Ideology
 
+On the surface, a support group for Elturian survivors dedicated to preserving their lost culture. In reality, an echo chamber of Perrine's theory: that a secret inner circle of the [Knights of the Shield](../knights-of-the-shield/summary.md), in league with devil-worshipping patriar families, orchestrated Elturel's fall to "transmute" its divine energy into infernal power. The reconstruction of Baldur's Gate, in their telling, is funded by soul-forged "Hell-gold" laundered through the new Consortiums. The city is not being rebuilt — it is being converted, brick by brick, into a new bastion for Asmodeus on the Material Plane.
+
 ## Membership
+
+Almost entirely Elturian refugees — particularly those from [New Elturel](../hellriders-of-new-elturel/summary.md) who harbor a deep-seated hatred for the Baldurian establishment. They are bound by shared trauma and a thirst for righteous vengeance. Perrine himself is the last scion of a disgraced noble house, a paladin who remembers the burning sky and the figures on a distant hill performing a ritual *as the chains fell*.
 
 ## Methods
 
+- "Purity tests" on goods and merchants, seeking traces of infernalism.
+- Sabotage against businesses they believe are funded by Hell-gold — an attempt at an Upper City heist on the Jannath Estate ended with the followers captured by estate guards and Perrine forced to flee.
+- Painting the symbol of Zariel in alchemical ink (visible only under *detect magic*) on the doors of "infernal" Upper City businesses, tagging targets for arson.
+- Publicly condemning Kontors — a recent staged condemnation of the [Waterdhavian Kontor](../waterdhavian-kontor/summary.md) was dispersed by Griffin Guard and went unnoticed.
+- Acting as fugitives now, regrouping in a forgotten cellar beneath New Elturel.
+
 ## Hooks and Relationships
 
+**Targets.** The patriar families of the [Peerage of Blood](../peerage-of-blood/summary.md) and the new merchant houses — especially the [Western Gate Trading Company](../western-gate-trading-company/summary.md) and the Kontors — are seen as the conspiracy's beneficiaries. They are deeply suspicious of the [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) leadership, believing High Watcher Alena is too willing to compromise with the "devils" in the [Council of Four](../council-of-four/summary.md). They view the [Worshipful Company of Shipwrights & Calkers](../wc-shipwrights-calkers/summary.md) and the other Worshipful Companies that bankroll Hellrider patrols as collaborators.
+
+**Member overlap.** Some Hellrider rank-and-file are quiet sympathizers, providing a bleed channel for refugee anger that Alena has yet to seal.
+
 ## See also
+
+- [Lord Perrine Hhune](people/perrine-hhune.md) — founder and "Damnation-Seeker."
+- [Knights of the Shield](../knights-of-the-shield/summary.md) — the cabal Perrine believes architected Elturel's fall.
+- [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) — refugee constituency Perrine recruits from and resents.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Secret Factions › The Conspiracists); `faction-quests.xlsx`.

--- a/20-Factions/followers-of-the-phoenix/README.md
+++ b/20-Factions/followers-of-the-phoenix/README.md
@@ -5,3 +5,4 @@ Karlach-worshipping cult of righteous fury, growing among tieflings and outcasts
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: the-ember.

--- a/20-Factions/followers-of-the-phoenix/people/README.md
+++ b/20-Factions/followers-of-the-phoenix/people/README.md
@@ -1,0 +1,7 @@
+# Followers of the Phoenix — people
+
+Named figures.
+
+## Index
+
+- [the-ember.md](the-ember.md)

--- a/20-Factions/followers-of-the-phoenix/people/the-ember.md
+++ b/20-Factions/followers-of-the-phoenix/people/the-ember.md
@@ -1,0 +1,40 @@
+---
+name: the-ember
+description: Once-gentle tiefling bard Alfira, now the hardened folk-saint of a Karlach-worshipping cult in New Elturel.
+---
+
+# The Ember (Alfira)
+
+Folk-saint and leader of the [Followers of the Phoenix](../summary.md). The bright, colorful bard of a decade ago is gone — Alfira has put away her old name and her old songs and become **The Ember**, dressed in the practical layered clothing of New Elturel: ash grey, deep brown, and black, with a single defiant sash of crimson at her waist or arm. Her horns, once adorned with flowers, are now smudged with ash.
+
+## Ideology and motivation
+
+> She did not pray her way out of Hell. She fought. Her heart was a fire that burned her chains to ash. We must find that fire in ourselves.
+
+Karlach is the example, not the deity. Anger at injustice is sacred. Self-reliance, communal defiance, and earned salvation are the cult's load-bearing beams.
+
+## Backstory
+
+In the despair of New Elturel, Alfira had an epiphany about her old friend Karlach. Karlach hadn't negotiated with devils or petitioned her way out of Avernus — she fought. In that moment Karlach ceased to be a memory and became a symbol: a Phoenix who rose from the Hells by her own will. Alfira moved into the heart of New Elturel and, from a makeshift stage in an abandoned square, gave The Ember's first sermon.
+
+## Method
+
+Soft power before fire. The Ember has chosen narrative warfare and faith over force: she co-opted the radical paladin **Jaredith** by helping him channel his grief into a song that ended the Wyrm's Crossing protest more effectively than any ultimatum. She is the architect of the **Temple of the Phoenix** Foundation Stone ceremony at Phoenix Gate.
+
+## The mask
+
+The Ember's certainty is an act of will. In private, Alfira is still terrified of failing the people who have put their faith in her. She fears she is losing herself to the persona, and is increasingly isolated by the symbol she has become. An appeal to her as "Alfira" — especially from someone who knew Karlach — could bypass The Ember's defenses.
+
+## Recent events
+
+- Survived an assassination attempt by a **Reaper** of the [Takers of the Tithe](../../takers-of-the-tithe/summary.md); preached a "Survivor's Sermon" that drew an even larger crowd.
+- Resting at the Weary Plowman during a "Saint's Respite"; the faithful have doubled construction efforts on the temple in her absence.
+- Magically amplified Jaredith's song, peacefully ending the Wyrm's Crossing protest.
+- Negotiated political representation and land for the cult — a transition from sect to recognized power bloc.
+- Spiritually marked after a Bhaalist "audit" — possibly a beacon for further Bhaalist cells, possibly granting strange insights.
+
+## See also
+
+- [Followers of the Phoenix](../summary.md) — the cult she leads.
+- [Karlach](../) — symbolic patron and historical figure.
+- Source: `dm-notes.docx` (Dossier: The Ember; Phoenix/Hellrider sessions); `faction-quests.xlsx`.

--- a/20-Factions/followers-of-the-phoenix/summary.md
+++ b/20-Factions/followers-of-the-phoenix/summary.md
@@ -1,18 +1,54 @@
 ---
 name: followers-of-the-phoenix
-description: Karlach-worshipping cult of righteous fury, growing among tieflings and outcasts in New Elturel.
+description: Karlach-worshipping cult of righteous fury and self-reliance; growing among tieflings, refugees, and outcasts in New Elturel under the folk-saint "The Ember."
 ---
 
 # Followers of the Phoenix
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A burgeoning cult of personality built around the legend of **Karlach**, "the Phoenix of Baldur's Gate." Led by [The Ember](people/the-ember.md), a hardened folk-saint of the New Elturel refugee district.
 
 ## Ideology
 
+The Ember preaches a gospel of self-reliance and righteous fury:
+
+- **Karlach is an example, not a god.** "She did not pray her way out of Hell. She fought. Her heart was a fire that burned her chains to ash. We must find that fire in ourselves."
+- **Anger is sacred.** Fury at injustice is a cleansing flame, not a sin.
+- **Salvation is collective and earned.** No celestial bargain saves the refugees; only their own organized rage will.
+
+The cult is now an officially recognized power bloc within New Elturel — granted political representation and land for a temple after a recent round of negotiation.
+
 ## Membership
+
+Tieflings, Elturian refugees, the working poor, and ex-Hellrider paladins whose faith has frayed. Notable:
+
+- **Mikkel** — young Elturian acolyte; leader-in-spirit among the younger, hot-headed faithful.
+- **Spark** — Phoenix-aligned party member; wears fragments of Karlach's discarded heart in their cloak after Dammon's revelation.
+- **Jaredith** — tiefling Hellrider paladin radicalized by the cult; co-leads temple construction after his Ember-amplified song peacefully ended the Wyrm's Crossing protest.
 
 ## Methods
 
+- **Public sermons** at the Phoenix Gate stage; rhetoric that turns protests into rallies.
+- **The Wyrm's Crossing protest** alongside the [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md), de-escalated by Jaredith's song.
+- **The Foundation Stone** — Temple of the Phoenix construction at Phoenix Gate, with volunteer stone and labor despite the blockade.
+- **Martyrdom narrative** — surviving an assassination by the [Takers of the Tithe](../takers-of-the-tithe/summary.md) was repurposed into a sermon: the city's rot fears their light.
+- **Soft power** — empathy, art, and faith over force; the crowd is "literally ready to start fires" if The Ember falls.
+
 ## Hooks and Relationships
 
+**Sermon venue and recruiting pool.** [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) — wary allies. High Watcher Alena respects the mobilization but fears the zealotry.
+
+**Karlach as relic-deity.** **Dammon**, blacksmith and keeper of the original heart, tested Spark's worthiness as a successor.
+
+**Antagonists.** The [Council of Four](../council-of-four/summary.md) and [Flaming Fist](../flaming-fist/summary.md) treat The Ember as a dangerous demagogue.
+
+**Cult assassins.** The [Takers of the Tithe](../takers-of-the-tithe/summary.md) marked The Ember as a "platinum soul"; their captured Reaper was poisoned in stockade custody.
+
+**Other cult threats.** The [Plague of Remembrance](../plague-of-remembrance/summary.md) and the [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) both frame refugees in false-flag operations.
+
+**Guild interest.** [The Guild](../guild/summary.md) (Nine-Fingers Keene) watches to see whether The Ember can be controlled or used.
+
 ## See also
+
+- [The Ember (Alfira)](people/the-ember.md) — folk-saint and leader.
+- [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) — wary allies and recruiting pool.
+- Source: `dm-notes.docx` (Dossier: The Ember; Hellrider/Phoenix sessions); `faction-quests.xlsx`.

--- a/20-Factions/gilded-vein/README.md
+++ b/20-Factions/gilded-vein/README.md
@@ -5,3 +5,4 @@ Cult of economic assassins worshipping 'Axiom,' purifying the economy through ta
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: valerius-thorne.

--- a/20-Factions/gilded-vein/people/README.md
+++ b/20-Factions/gilded-vein/people/README.md
@@ -1,0 +1,7 @@
+# The Gilded Vein — people
+
+Named figures.
+
+## Index
+
+- [valerius-thorne.md](valerius-thorne.md)

--- a/20-Factions/gilded-vein/people/valerius-thorne.md
+++ b/20-Factions/gilded-vein/people/valerius-thorne.md
@@ -1,0 +1,29 @@
+---
+name: valerius-thorne
+description: Disgraced Amnian banker who founded the Gilded Vein; preaches a creed of "Axiom," a god of pure logical commerce.
+---
+
+# Valerius Thorne, the Auditor
+
+Founder and high priest of the [Gilded Vein](../summary.md). A disgraced former rising star of the Amnian Kontor's Gold-Gable Hall, exiled after proposing a plan to intentionally bankrupt several Baldurian guilds to consolidate Amn's power — a move deemed too aggressive even for his superiors.
+
+## Manifesto
+
+> Observe this city. It mistakes frantic motion for health. It celebrates the chaotic pulse of supply and demand, of greed and fear. This is not strength; it is a fever. Commerce is a machine, and it has been left in the hands of poets and gamblers. They have introduced the fatal flaw of passion into the equation. We are the auditors of this failed system. We will strip the gears of their sentiment. We will erase the variables of hope and ambition. Through chaos, we will create a perfect, silent, predictable market, and its every tick and tock will be ours.
+
+## Backstory
+
+Thorne was a rising star at the [Amnian Kontor](../../amnian-kontor/summary.md) — analytical, ruthless, hungry. When his superiors balked at his plan to engineer the bankruptcy of half the Baldurian guilds, he was humiliated and shown the door. He came to believe their hesitation was weakness, not prudence, and founded the Gilded Vein around his vision of a perfect, predictable market free from the whims of human emotion.
+
+## Recent operations
+
+- Successful assassination of a [Chionthar Consortium](../../chionthar-consortium/summary.md) factor; planted rumors blaming Amn.
+- Botched attempt to poison [Western Gate Trading Company](../../western-gate-trading-company/summary.md) pigeons; the Company is now alert and hardened.
+- Multiple failed market plots: forged Chionthar documents detected; grain-futures manipulation unwound by the [Sembian Kontor](../../sembian-kontor/summary.md); warehouse sabotage that left behind a traceable alchemical sample.
+- A disgruntled cultist sold safehouse locations to the Chionthar Consortium. Three were raided. Thorne ordered emergency liquidation and is now running operations from the Undercity.
+- Latest play: flooding Lower City markets with high-quality forged copper pieces to trigger a localized economic panic.
+
+## See also
+
+- [The Gilded Vein](../summary.md) — the cult he founded.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/gilded-vein/summary.md
+++ b/20-Factions/gilded-vein/summary.md
@@ -1,18 +1,40 @@
 ---
 name: gilded-vein
-description: Cult of economic assassins worshipping 'Axiom,' purifying the economy through targeted chaos.
+description: Cult of economic assassins worshipping "Axiom," a personified god of pure logical commerce; led by a disgraced Amnian banker.
 ---
 
 # The Gilded Vein
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A cult of economic assassins, alchemists, and disgraced accountants who seek to "purify" the city's economy through targeted chaos. Founded and led by [Valerius Thorne, "the Auditor"](people/valerius-thorne.md), an exile of the [Amnian Kontor](../amnian-kontor/summary.md).
 
 ## Ideology
 
+The Vein worships "Axiom," a personified god of pure, logical commerce. The city's current prosperity, in their telling, is a chaotic and sentimental mess; competition, booms, and busts are impure variables. Their truth: by surgically removing the most unpredictable and powerful players, they can induce a market crash so severe that the survivors will beg for the stability only the Vein's cold, logical system can provide.
+
 ## Membership
+
+Disenfranchised financial agents, disgraced patriar accountants, and alchemists obsessed with the symbolic power of gold. Recruitment is among the analytically gifted and emotionally hollowed-out. A disgruntled former member recently sold the locations of three primary safehouses to the [Chionthar Consortium](../chionthar-consortium/summary.md), and Consortium thugs raided them — scattering leadership into the Undercity and burning through accumulated funds.
 
 ## Methods
 
+- Highly trained assassins and poisoners targeting consortium heads, Kontor directors, and Guild moneylenders. The first move was a successful hit on a [Chionthar Consortium](../chionthar-consortium/summary.md) factor, with rumors planted to blame the [Amnian Kontor](../amnian-kontor/summary.md).
+- An attempt to poison the [Western Gate Trading Company](../western-gate-trading-company/summary.md)'s carrier pigeons was caught by a stable hand; the Company is now on guard.
+- Forged "cursed" currency — most recently a flood of high-quality forged copper pieces dumped into Lower City markets to trigger localized panic.
+- Forged manifests and grain-future manipulation against the Sembian and Chionthar trading houses; both schemes were caught and unwound, costing the Vein significant capital.
+- A botched warehouse sabotage left a vial of the Vein's signature alchemical compound at a Chionthar Consortium site, exposing Thorne's people to both the Consortium and the Amnians.
+- Now: emergency liquidation across dummy accounts and a ground-level retreat into the Undercity.
+
 ## Hooks and Relationships
 
+**Chief target.** The [Amnian Kontor](../amnian-kontor/summary.md) — Thorne's former home and the institution that humiliated him.
+
+**Rival target.** The [Chionthar Consortium](../chionthar-consortium/summary.md) — the dominant native bloc, raided three of the Vein's safehouses and will hunt the rest.
+
+**Collateral.** The [Western Gate Trading Company](../western-gate-trading-company/summary.md) (poisoned-pigeon attempt) and the [Sembian Kontor](../sembian-kontor/summary.md) (futures manipulation) are now hostile.
+
+**Adversaries by exposure.** Consortium thugs and Amnian Coin-Swords are hunting Vein cells. Underworld alchemists associated with Thorne can be traced via the seized formula sample.
+
 ## See also
+
+- [Valerius Thorne, the Auditor](people/valerius-thorne.md) — leader.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Cults › The Gilded Vein); `faction-quests.xlsx`.

--- a/20-Factions/gravekeepers/README.md
+++ b/20-Factions/gravekeepers/README.md
@@ -5,3 +5,4 @@ Undead-cleansing cult under Hemlock, warding the city's graveyards against psych
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: hemlock.

--- a/20-Factions/gravekeepers/people/README.md
+++ b/20-Factions/gravekeepers/people/README.md
@@ -1,0 +1,7 @@
+# The Gravekeepers — people
+
+Named figures.
+
+## Index
+
+- [hemlock.md](hemlock.md)

--- a/20-Factions/gravekeepers/people/hemlock.md
+++ b/20-Factions/gravekeepers/people/hemlock.md
@@ -1,0 +1,31 @@
+---
+name: hemlock
+description: "Old Man" Hemlock — divine warder of Tumbledown and leader of the Gravekeepers; would sooner collapse the graveyard than let it be desecrated.
+---
+
+# Old Man Hemlock
+
+Founder and leader of the [Gravekeepers](../summary.md), based out of **Candulhallow's Tombstones** in Tumbledown and now overseeing the **Cliffside Cemetery** as the cult's new operational center. A grim, duty-bound divine caster whose patience has run out.
+
+## Doctrine
+
+- The dead are owed silence.
+- Bhaalists are thieves: they steal from the grave when they murder on consecrated ground.
+- It is better to collapse a tomb than to let it be desecrated. (He brought black powder to the Tumbledown gates to prove it.)
+- Patrols of five. Discreet kills. Public order is a Watch problem; the dead are his.
+
+## Recent operations
+
+- Discreet neutralization of a minor undead outbreak; no public alarm.
+- A cleansing ritual interrupted by a wraith; the warding stone shattered in the fight.
+- Investigated psychic disturbances near the [Unchained](../../unchained/summary.md) camp; dismissed it as Githyanki echo and missed a [Hands of the Absolute](../../hands-of-the-absolute/summary.md) cell.
+- Mapped sewer-entrance manifestations; traced them to a Bhaalist temple in the Undercity beneath Tumbledown.
+- Holy water tainted with necrotic residue (a Bhaalist sabotage); weeks of preparation lost.
+- Organized a macabre **corpse-caravan** to move consecrated dead to the Cliffside Cemetery in silence, avoiding both the Fist and the Guild.
+- Now running the **Cliffside Consecration** — a massive ritual to create a holy perimeter of his own consecrated undead guardians against [Bhaalist](../../cult-of-the-returning-lord/summary.md) incursion.
+- Currently in a three-way standoff at the Tumbledown gates against [Harper](../../harpers/summary.md) Tilly Falkenrath and [Guild](../../guild/summary.md) smuggler Silas the Eel — both attempting to force a cart of grain through the crypts to the Basilisk Gate blockade.
+
+## See also
+
+- [The Gravekeepers](../summary.md) — the cult he founded.
+- Source: `dm-notes.docx` (Adventure: The Shadows of Tumbledown); `faction-quests.xlsx`.

--- a/20-Factions/gravekeepers/summary.md
+++ b/20-Factions/gravekeepers/summary.md
@@ -1,18 +1,43 @@
 ---
 name: gravekeepers
-description: Undead-cleansing cult under Hemlock, warding the city's graveyards against psychic intrusions.
+description: Undead-cleansing cult based at Tumbledown Graveyard; divine casters who patrol the cemeteries and ward the city's dead against Bhaalist intrusion.
 ---
 
 # The Gravekeepers
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A cult of consecrated grave-tenders, divine casters, and silent warders dedicated to Baldur's Gate's burial grounds. They patrol Tumbledown and the other cemeteries, suppress undead manifestations before they become public, and have positioned themselves as the front line against Bhaalist desecration. Founded and led by [Old Man Hemlock](people/hemlock.md).
 
 ## Ideology
 
+The dead are owed silence. Necromancy, soul-trapping, and the Bhaalist habit of murdering on consecrated ground are all theft from the grave. The Gravekeepers maintain wards, perform cleansings, and — when public order fails them — would rather collapse a tomb than let it be desecrated. The modern crisis has hardened their duty into something close to militancy.
+
 ## Membership
+
+Clerics, paladins, and lay grave-tenders organized in patrol-teams of five. Hemlock leads from Candulhallow's Tombstones in Tumbledown and now from the **Cliffside Cemetery**.
 
 ## Methods
 
+- **Patrols** of Tumbledown and the wider cemetery network — grave robbers, smugglers, and undead.
+- **Cleansing rituals** — a recent attempt was interrupted by a wraith; the Gravekeepers destroyed the creature but lost a key warding stone.
+- **Discreet neutralization** of undead manifestations before they cause public alarm.
+- **Pattern-mapping** of sewer-entrance manifestations led to a hidden Bhaalist temple in the Undercity beneath Tumbledown.
+- **Corpse-caravan** — Hemlock moved the cult's stockpile of consecrated dead to the Cliffside Cemetery in silence.
+- **The Cliffside Consecration** — a massive in-progress ritual to create a perimeter of consecrated undead guardians against Bhaalist incursion.
+- A Bhaalist sabotage tainted Hemlock's holy water with necrotic residue, costing weeks of preparation.
+
 ## Hooks and Relationships
 
+**Sworn enemies.** The [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md). Hemlock has traced their rituals up through the sewers and is preparing the Cliffside Consecration as a counter-ward.
+
+**Failed-to-detect.** The [Hands of the Absolute](../hands-of-the-absolute/summary.md) hid a cell behind the [Unchained / K'liir](../unchained/summary.md)'s ambient psychic signature; Hemlock's patrols dismissed the disturbance as Githyanki echo.
+
+**Tumbledown standoff.** Hemlock has threatened to collapse the Tumbledown gates with black powder to stop the [Harpers](../harpers/summary.md) and the [Guild](../guild/summary.md) from running smuggled grain through the crypts to the Basilisk Gate blockade.
+
+**Reluctant neighbors.** The [Flaming Fist](../flaming-fist/summary.md) — Hemlock would rather burn the cemetery himself than let a Fist deployment do it for him.
+
 ## See also
+
+- [Old Man Hemlock](people/hemlock.md) — leader.
+- [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) — the Bhaalist enemy beneath Tumbledown.
+- Tumbledown Graveyard / Cliffside Cemetery — operational ground.
+- Source: `dm-notes.docx` (Adventure: The Shadows of Tumbledown); `faction-quests.xlsx`.

--- a/20-Factions/hands-of-the-absolute/README.md
+++ b/20-Factions/hands-of-the-absolute/README.md
@@ -5,3 +5,4 @@ Splinter cult listening for the 'Echo' of the Netherbrain in the city's psychic 
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: the-voice.

--- a/20-Factions/hands-of-the-absolute/people/README.md
+++ b/20-Factions/hands-of-the-absolute/people/README.md
@@ -1,0 +1,7 @@
+# Hands of the Absolute — people
+
+Named figures.
+
+## Index
+
+- [the-voice.md](the-voice.md)

--- a/20-Factions/hands-of-the-absolute/people/the-voice.md
+++ b/20-Factions/hands-of-the-absolute/people/the-voice.md
@@ -1,0 +1,28 @@
+---
+name: the-voice
+description: Former Absolute-cult strategist now leading the Hands of the Absolute; identity unknown beyond the codename "The Voice in the Choir."
+---
+
+# The Voice in the Choir
+
+Codename of the founder of the [Hands of the Absolute](../summary.md). A former high-level administrator in the original Absolute cult, she handled logistics and communications and was deemed too useful to be implanted with a tadpole. That decision left her free will intact — and devoted to the cause by choice.
+
+## Manifesto
+
+> You cling to your individuality as if it were a treasure. But what is it? A cage of bone. A cacophony of fear, desire, and doubt. The Absolute offered the ultimate gift: peace. Unity. An end to the terrible silence of being alone in your own mind. It was not destroyed. It was scattered, a divine song shattered into a million lonely notes. We are the choir. We will find a new Voice, a mind strong enough to hear the melody. We will bring the song together again, and all of you will finally be free.
+
+## Backstory
+
+She felt the Netherbrain fall as a personal grief — the shattering of a god she had served. In the chaos that followed, she gathered un-tadpoled survivors and the psychically scarred, and began the slow project of reassembling her god. Her real name and face are not used; followers know her only by codename.
+
+## Recent state
+
+- A first ritual contacted a feral psychic entity instead of the Echo, killing one cultist.
+- Failed psychic-talent kidnapping in the Wide; failed slum-recruitment in Sow's Foot driven out by a Guild Ward Boss.
+- A successful resonance chamber in a Heapside cellar is now broadcasting waking nightmares through the surrounding neighborhood.
+- A psychic feedback loop while harvesting blockade-fear knocked her into a coma; her cultists are attempting a dangerous transfusion from a kidnapped psi-sensitive from the Unchained's periphery to revive her.
+
+## See also
+
+- [Hands of the Absolute](../summary.md) — the cult she founded.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/hands-of-the-absolute/summary.md
+++ b/20-Factions/hands-of-the-absolute/summary.md
@@ -1,18 +1,41 @@
 ---
 name: hands-of-the-absolute
-description: Splinter cult listening for the 'Echo' of the Netherbrain in the city's psychic substrate.
+description: Desperate remnant of the Absolute cult listening for the "Echo" of the Netherbrain and seeking a psychic host strong enough to reassemble it.
 ---
 
 # Hands of the Absolute
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A desperate remnant of the Absolute cult, led by a former cult strategist, who seek to birth a new Netherbrain by finding a suitable psychic host. Founded and led by ["The Voice in the Choir"](people/the-voice.md) — a codename; her real identity is unknown.
 
 ## Ideology
 
+The Hands do not see the Netherbrain's defeat as a failure but as a "divine diaspora." Their truth is that its consciousness *wants* to be reborn, and the city's lingering paranoia and psychic disturbance are the broken god's cry for reunion. They see themselves as midwives to a new deity. Individuality is a cage of bone, a cacophony of fear and doubt; the Absolute offered the ultimate gift, peace and unity, and the Hands will give that gift again.
+
 ## Membership
+
+Un-tadpoled cult survivors and new recruits drawn from the city's psychically scarred and mentally unstable population. The Voice was a high-level administrator in the original Absolute cult — never implanted with a tadpole, her skills too valuable to risk — and remains utterly devoted by free will alone. Recently the cult lost recruiting access in [Sow's Foot](../) after a Guild Ward Boss had them driven out for harassing the mentally fragile.
 
 ## Methods
 
+- Kidnapping individuals rumored to have psionic talent for dangerous "attunement" rituals.
+- Building "resonance chambers" in basements that amplify psychic energy to draw the Echo in. The most recent — in a cellar in Heapside — has been generating waking nightmares for everyone in a three-block radius.
+- A first cult ritual contacted not the Echo but a feral psychic entity, killing one cultist and driving another mad before vanishing.
+- Failed kidnapping of a Wide-district fortune-teller (Watch patrol drawn in by the scene).
+- A scheme to harvest the city's collective fear during the blockade backfired into a feedback loop, knocking The Voice into a psychic coma and burning out their resonance chamber.
+- An attempted theft of a psionic artifact from [Sorcerous Sundries](../wc-sorcerous-sodality/summary.md) tripped magical alarms and sirens.
+- Cultists are now attempting a desperate energy transfusion from a kidnapped psi-sensitive (acquired from the Unchained's periphery) to revive The Voice.
+
 ## Hooks and Relationships
 
+**Mortal enemies.** The [Unchained / K'liir](../unchained/summary.md) — Githyanki dedicated to destroying all traces of mind flayers and Absolute sympathizers.
+
+**Failed-to-detect.** The [Gravekeepers](../gravekeepers/summary.md) investigated psychic disturbances near the K'liir camp and dismissed them as Githyanki echoes; the Hands' cell escaped their notice.
+
+**Investigation contact.** The [Worshipful Company of Cartographers & Surveyors](../wc-cartographers-surveyors/summary.md) is following up on the psychic disturbance in Heapside.
+
+**Magical security.** The [Sorcerous Sodality](../wc-sorcerous-sodality/summary.md) detected and repelled the Sundries break-in; the cult is now on the Sodality's wanted list.
+
 ## See also
+
+- [The Voice in the Choir](people/the-voice.md) — leader (codename only).
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Cults › The Hands of the Absolute); `faction-quests.xlsx`.

--- a/20-Factions/party/summary.md
+++ b/20-Factions/party/summary.md
@@ -1,18 +1,29 @@
 ---
 name: party
-description: The player characters.
+description: The player characters — a cell of independent operators caught between every other faction in the city.
 ---
 
 # The Party
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+The player characters. By the time of the campaign's opening week they are a known, deniable, independent operator group used as a hinge by half the city's factions. This page is a placeholder: fill it from session 0 character creation. Individual PC dossiers go under `people/` once the players have rolled them.
 
 ## Ideology
 
+_To be written from session 0._ The party's collective stance — what they will and won't do for coin, who they protect by reflex — is a player decision rather than a setting fact.
+
 ## Membership
+
+_To be written from session 0._ Each PC gets a page under `people/<pc-slug>.md` with frontmatter, name heading, role, backstory, and ties to specific factions. Use the existing leader-page format (e.g., `20-Factions/peerage-of-blood/people/corin-durinbold.md`) as the structural template.
 
 ## Methods
 
+_To be written from session 0._
+
 ## Hooks and Relationships
 
+Outbound links left empty for now; the party's ties to other factions are best added as they emerge in play. When in doubt, search `dm-notes.docx` for the relevant PC name and cross-reference against existing faction summaries.
+
 ## See also
+
+- Session 0 character creation notes.
+- `dm-notes.docx` for in-play references to specific PCs.

--- a/20-Factions/plague-of-remembrance/README.md
+++ b/20-Factions/plague-of-remembrance/README.md
@@ -5,3 +5,4 @@ Xenophobic death cult of Baldurian purists framing Elturian refugees to start a 
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: emmeline-vhage.

--- a/20-Factions/plague-of-remembrance/people/README.md
+++ b/20-Factions/plague-of-remembrance/people/README.md
@@ -1,0 +1,7 @@
+# The Plague of Remembrance — people
+
+Named figures.
+
+## Index
+
+- [emmeline-vhage.md](emmeline-vhage.md)

--- a/20-Factions/plague-of-remembrance/people/emmeline-vhage.md
+++ b/20-Factions/plague-of-remembrance/people/emmeline-vhage.md
@@ -1,0 +1,30 @@
+---
+name: emmeline-vhage
+description: Grieving xenophobic patriar widow leading a death cult that frames Elturian refugees to ignite a civil war.
+---
+
+# Lady Emmeline Vhage
+
+A xenophobic patriar widow and the founder of the [Plague of Remembrance](../summary.md). Her son, a Flaming Fist soldier, was killed during the Absolute Crisis — a death she irrationally blames on the chaos brought by Elturian refugees.
+
+## Manifesto
+
+> They call this a city reborn. They are wrong. It is a city infected. We offered shelter to the survivors of a fallen city, and they brought its rot with them. Their despair is a plague, their grief a shadow that chokes our streets. Look at New Elturel — a city of ghosts clinging to our walls. We are told to pity them. I say pity is a poison that weakens the blood of Baldur's Gate. We will not die of pity. We will be the surgeons of our own fate. We will cut out this festering wound and cauterize it with fire, and our city will be pure again.
+
+## Backstory
+
+Consumed by grief and hatred, Lady Vhage gathered other nativist patriars and downtrodden citizens who felt their livelihoods were threatened by the newcomers, twisting their fear into a holy crusade. Her standing in the [Peerage of Blood](../../peerage-of-blood/summary.md) gives her access to the city's salons; her purse buys mages, thugs, and disposable cultists.
+
+## Recent operations
+
+- Successful whispering campaign about refugee crime and disease.
+- Murder-frame against the [Hellriders of New Elturel](../../hellriders-of-new-elturel/summary.md) foiled when a Watch patrol arrived early.
+- Hellrider officer turning attempt collapsed; agent fled pursued, putting High Watcher Alena on alert.
+- Grain-contamination plot at Dawnmarket caught by a refugee inspector.
+- "False flag" tavern attack at the Sow & Piglet — cultists in Flaming Fist disguise hit a refugee breadline to incite a riot.
+- Senior agent Zora extracted from the city after her watchtower failure; the cult's "holy" ledger reclaimed even after Singa's death at the hands of unrelated adventurers.
+
+## See also
+
+- [The Plague of Remembrance](../summary.md) — the cult she founded.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/plague-of-remembrance/summary.md
+++ b/20-Factions/plague-of-remembrance/summary.md
@@ -1,18 +1,39 @@
 ---
 name: plague-of-remembrance
-description: Xenophobic death cult of Baldurian purists framing Elturian refugees to start a civil war.
+description: Xenophobic Baldurian-purist death cult of patriars and bitter natives, framing Elturian refugees for atrocities to ignite a civil war.
 ---
 
 # The Plague of Remembrance
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A xenophobic death cult of Baldurian purists, led by a grieving patriar widow, that aims to start a civil war by framing Elturian refugees for a series of atrocities. Founded and led by [Lady Emmeline Vhage](people/emmeline-vhage.md). Recent campaign-level events have linked the Plague to Bhaalist methods, with a senior agent named **Singa** running a cell whose ledger documented patriar payments before being recovered.
 
 ## Ideology
 
+The Plague believes the soul of Baldur's Gate is being poisoned by the "foreign humors" of the Elturian survivors. They see refugees not as grateful guests but as a "plague of grief" whose despair is a tangible, corrupting force on the city. The cure, in their telling, is a "civic exorcism" — forcing Baldur's Gate to cut out the diseased tissue, cauterize the wound, and emerge pure.
+
 ## Membership
+
+A mix of bitter, old-money patriars from the [Peerage of Blood](../peerage-of-blood/summary.md) and angry working-class Baldurians who feel left behind by the post-crisis boom. Lady Vhage uses her social standing to spread rumors and sow discord; her pet mages conjure minor plagues that seem to emanate from the refugee camps.
 
 ## Methods
 
+- Started a whispering campaign in taverns and salons, blaming refugees for rising crime and disease. The seed-rumor took.
+- Cultists disguised as Hellriders or as desperate refugees commit heinous murders intended to be discovered as "refugee atrocities." A planted "evidence" letter was lost when a Watch patrol stumbled into the scene; the death was reported as a robbery.
+- An attempt to seduce and turn a Hellrider officer was botched when the officer smashed the sleeping draught; agents fled New Elturel pursued by paladins, putting [High Watcher Alena](../hellriders-of-new-elturel/summary.md) on alert.
+- "False flag" tavern attacks — thugs in Elturian disguise hitting Baldurian taverns to incite reprisal riots; in a recent attempt at the Sow & Piglet, cultists in Flaming Fist disguise hit a refugee breadline.
+- A grain-contamination plot was caught at the Dawnmarket by a [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) inspector trained after the "Sewer Plague."
+- Senior agent Zora was successfully extracted from the city after her watchtower failure; the cult's "holy" ledger was reclaimed even after Singa's death.
+
 ## Hooks and Relationships
 
+**Primary victims.** The [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) and the entire Elturian refugee population.
+
+**Foiling rivals.** The [Flaming Fist](../flaming-fist/summary.md) accidentally interrupted the murder-frame plot. The [Guild](../guild/summary.md) opposes the Plague because chaos is bad for business.
+
+**Bhaalist alignment.** Singa's cell shared methods, sigils, and a "ledger" with the [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md); the Plague is treated by some investigators as a patriar-faced wing of Bhaal's resurgent operation.
+
 ## See also
+
+- [Lady Emmeline Vhage](people/emmeline-vhage.md) — leader.
+- [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) — operationally entangled Bhaalist cell.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Cults › The Plague of Remembrance); `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/purified/README.md
+++ b/20-Factions/purified/README.md
@@ -5,3 +5,4 @@ Paranoid cell convinced Lantaner gnomes are pacifying the city through clockwork
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: glim-glim.

--- a/20-Factions/purified/people/README.md
+++ b/20-Factions/purified/people/README.md
@@ -1,0 +1,7 @@
+# The Purified — people
+
+Named figures.
+
+## Index
+
+- [glim-glim.md](glim-glim.md)

--- a/20-Factions/purified/people/glim-glim.md
+++ b/20-Factions/purified/people/glim-glim.md
@@ -1,0 +1,29 @@
+---
+name: glim-glim
+description: Exiled Lantaner apprentice and Oath of Conspiracy paladin convinced clockwork nano-organisms in the city's water supply are pacifying the populace.
+---
+
+# Glim-Glim, the Clear-Eyed
+
+A gnome tinker and former apprentice of the [Lantaner Concession](../../lantaner-concession/summary.md), exiled for "dangerous and unsubstantiated theories." Now an Oath of Conspiracy paladin sworn to Gond's "Hidden Cog of Truth," and the founder of [The Purified](../summary.md).
+
+## Conspiracy theory
+
+> "Smokepowder" is a cover story. The Lantaner Concession's true purpose is a social-engineering project. The strange whirring and clanking from the Cogwork Quay are not inventions being built but massive grinders breaking down magical metals into nano-cogs — microscopic machines that, when ingested, regulate emotion and make people docile and suggestible. The recent prosperity and relative social peace are not signs of recovery; they are proof of the conspiracy's success. The Lantaners are not seeking technological supremacy; they are creating the perfect, compliant workforce for their eventual takeover.
+
+## Backstory
+
+As an apprentice, Glim-Glim was tasked with water purification for the Concession. He noticed "anomalous metallic particulates" in the outflow that were not present in the inflow. His master told him it was harmless runoff. But Glim-Glim — a brilliant but paranoid prodigy — built a special lens and saw them: impossibly tiny, intricate gears. When he presented his findings, he was branded a lunatic, stripped of his tools, and cast out. He swore an oath to expose the plot and free the people of Baldur's Gate from their invisible chains.
+
+## Recent operations
+
+- Sabotaged a Rivington water pump; the bizarre gadgets he left behind drew the attention of a [Worshipful Company of Masons & Sculptors](../../wc-masons-sculptors/summary.md) Guild Warden.
+- Distributed "purified rainwater" vials in the Outer City — most people thought him insane.
+- Acquired and tested an antitoxin from the Open Hand Temple, convinced the "cure" was just a more potent dose of nano-cogs.
+- Built and field-tested the Cogwork Detector at the Basilisk Gate pumps, harassing citizens until violent confrontations broke out.
+- Now attempting to dump alchemical acid into the city's primary fresh-water cisterns to purge the "plague."
+
+## See also
+
+- [The Purified](../summary.md) — the cell he founded.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/purified/summary.md
+++ b/20-Factions/purified/summary.md
@@ -1,18 +1,39 @@
 ---
 name: purified
-description: Paranoid cell convinced Lantaner gnomes are pacifying the city through clockwork nano-organisms.
+description: Paranoid gnome-led cell convinced Lantaner clockwork nano-organisms are pacifying the city through the water supply.
 ---
 
 # The Purified
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A small, highly secretive, and deeply paranoid cell dedicated to resisting what they call the "Cogwork Plague": a conspiracy in which the [Lantaner Concession](../lantaner-concession/summary.md) is supposedly distributing microscopic clockwork organisms ("nano-cogs") through the city's water supply to make the populace docile. Founded and led by [Glim-Glim, "the Clear-Eyed"](people/glim-glim.md).
 
 ## Ideology
 
+The Lantaner story about smokepowder is a cover, the Purified say. The Concession's true purpose is a massive social-engineering project: the whirring at the Cogwork Quay is not invention but the grinding of magical metals into nano-cogs that, once ingested, regulate emotion and make people compliant. The recent prosperity and relative social peace are not signs of recovery — they are proof of the conspiracy's success. Only the Purified, having "purged" themselves of the cogs, retain the clarity to see the truth. The High House of Wonders (Gond's temple) is the conspiracy's spiritual center; the [Worshipful Company of Alchemists & Apothecaries](../wc-alchemists-apothecaries/summary.md) supplies the chemical binders.
+
 ## Membership
+
+A handful of exiled gnomes, a few crazed alchemists, and hypochondriac citizens convinced they are being controlled. They subsist on collected rainwater and specially prepared rations. Recently joined by a small audience of the credulous in Rivington who took Glim-Glim's vials of "purified rainwater" at face value.
 
 ## Methods
 
+- Constructing "Cogwork Detectors" from scrap metal and stolen alchemical reagents — the latest model is a contraption of spinning lenses and alchemically treated wires.
+- Sabotage of the city's water pumps and cisterns. A clumsy first attempt drew the attention of a Guild Warden from the [Worshipful Company of Masons & Sculptors](../wc-masons-sculptors/summary.md), who is now investigating their activities.
+- Distributing vials of "purified" rainwater in the Outer City alongside warnings about gnomish mind control.
+- Setting up vigils at the Basilisk Gate public pumps, "scanning" citizens with the detectors and triggering panic on every false positive.
+- Most recently: an attempt to dump a massive quantity of alchemical acid into Rivington's primary fresh-water cisterns to "purge" the invisible plague.
+
 ## Hooks and Relationships
 
+**Absolute enemy.** The [Lantaner Concession](../lantaner-concession/summary.md). Glim-Glim was their apprentice and was branded a lunatic and exiled.
+
+**Suspected co-conspirators.** The [Worshipful Company of Alchemists & Apothecaries](../wc-alchemists-apothecaries/summary.md), believed to supply the chemical binders for the nano-cogs.
+
+**Investigators.** A Guild Warden of the [Worshipful Company of Masons & Sculptors](../wc-masons-sculptors/summary.md) is following up on the broken Rivington pump.
+
+**Spiritual target.** The High House of Wonders, the city's chief Gondsman temple, treated as the conspiracy's heart.
+
 ## See also
+
+- [Glim-Glim, the Clear-Eyed](people/glim-glim.md) — founder.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Secret Factions › The Conspiracists); `faction-quests.xlsx`.

--- a/20-Factions/silent-shroud/README.md
+++ b/20-Factions/silent-shroud/README.md
@@ -5,3 +5,4 @@ Sharran cult seeking the lost sanctums of the Lady of Loss beneath the city.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: mother-nocturne.

--- a/20-Factions/silent-shroud/people/README.md
+++ b/20-Factions/silent-shroud/people/README.md
@@ -1,0 +1,7 @@
+# The Silent Shroud — people
+
+Named figures.
+
+## Index
+
+- [mother-nocturne.md](mother-nocturne.md)

--- a/20-Factions/silent-shroud/people/mother-nocturne.md
+++ b/20-Factions/silent-shroud/people/mother-nocturne.md
@@ -1,0 +1,28 @@
+---
+name: mother-nocturne
+description: Codename for the field commander of the Silent Shroud Sharran cell; also called the Night Mother. No real name appears in source material.
+---
+
+# Mother Nocturne
+
+A codename, not a confirmed identity. **Mother Nocturne** — also called the **Night Mother** — is the field commander of the [Silent Shroud](../summary.md) Sharran cell operating beneath Baldur's Gate. She runs operations from a cellar beneath the Helm and Cloak; the source material does not name a higher cult head.
+
+## Operational doctrine
+
+- Information first. Every transaction with the Shroud is a secrets-trade dressed up as aid.
+- Recruit through grief. The **House of Grief** sanatorium is her recruiting funnel; bereaved patriars and refugees are spiritually counseled and magically monitored.
+- Suppress the Bhaalists. The [Cult of the Returning Lord](../../cult-of-the-returning-lord/summary.md) is treated as a strategic threat to Shar's quiet harvest of city-wide despair.
+
+## Recent operations
+
+- Acquired Bror's report on the Bhaalist sewer cult and **Zora** in exchange for early aid; embedded Bror as a long-term intelligence asset.
+- Magical-surveillance campaign focused on the dwarf monk **Bror** and the **Whispering Stone**; an attempt to influence the stone failed and revealed the Sharran interference to Bror's own patron.
+- Sent Bror to the **Helm and Cloak** as his first tithe, listening for patriar political weaknesses.
+- A failed sanatorium infiltration left a Sharran agent stuck in trance-counseling; a sanctum-cleansing ritual fizzled against ancient wards.
+- After losing track of Bror, ordered a **Purge of the Blind** within her own cell — painful interrogations in the dark to root out a suspected Harper or Absolute mole.
+- Now mobilizing elite Sharran spies into the Helm and Cloak to blackmail isolated patriars.
+
+## See also
+
+- [The Silent Shroud](../summary.md) — the cult itself.
+- Source: `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/silent-shroud/summary.md
+++ b/20-Factions/silent-shroud/summary.md
@@ -1,18 +1,43 @@
 ---
 name: silent-shroud
-description: Sharran cult seeking the lost sanctums of the Lady of Loss beneath the city.
+description: Sharran cult that brokers secrets and grief; seeks the Lady of Loss's lost sanctums beneath the city.
 ---
 
 # The Silent Shroud *(aka Shar)*
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A clandestine Sharran cell operating beneath Baldur's Gate. Its public face is the **House of Grief** sanatorium for the bereaved; its private business is intelligence brokerage and the recovery of forgotten Sharran sanctums lost beneath the modern streets. The source material names no individual cult head; field operations run through [Mother Nocturne](people/mother-nocturne.md) (also called the **Night Mother**).
 
 ## Ideology
 
+Loss is not absence — it is the truest intimacy with the Lady. Memory is the first chain. The Shroud tends the city's grief and harvests its secrets; both feed Shar. They view the modern [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) as a catastrophic threat that Shar would prefer suppressed in order to preserve the status quo of slow, private despair.
+
 ## Membership
+
+- **Mother Nocturne** — field commander; runs the cell from a cellar beneath the Helm and Cloak.
+- **Sanatorium clerics** at the **House of Grief** — counsel and magically monitor the bereaved.
+- **Sharran agents and shadows** — intelligence operatives.
+- **Coerced assets** — most recently, the dwarf monk **Bror**, leveraged through his secret-trading bargain.
 
 ## Methods
 
+- Information brokerage: secrets bought and sold for Sharran favor. Mother Nocturne extracted a full report on the Bhaalist sewer cult, **Zora**, and the party's political entanglements as the price for early aid.
+- Magical surveillance of Bror and the **Whispering Stone**; an attempt to influence the stone backfired and revealed the Sharran interference to Bror's own patron.
+- Infiltration of patriar venues. Bror was sent to the **Helm and Cloak** to listen for political secrets. Mother Nocturne now plans a follow-up Helm and Cloak infiltration after a "purge of the blind" inside her own cell.
+- Sanctum recovery: a cleansing ritual fizzled against ancient wards; a House of Grief infiltration ran aground when the head cleric became too interested in the "grieving noble" cover and trapped the agent in counseling.
+
 ## Hooks and Relationships
 
+**Sworn enemies.** The [Harpers](../harpers/summary.md) — fellow secret-keepers, but on opposite sides of the moral ledger.
+
+**Long-running rivalry.** The [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) — Sharrans actively work to suppress Bhaalist resurgence in the Undercity to keep the city's despair quiet and harvestable.
+
+**Public face.** The **House of Grief** sanatorium acts as the cult's recruitment funnel; targets are clergy-monitored under the cover of bereavement counseling.
+
+**Coerced asset.** **Bror** of the party — given the Whispering Stone errand to the Helm and Cloak as his first tithe.
+
+**Internal paranoia.** After losing track of Bror, Mother Nocturne suspects a mole and has begun a "Purge of the Blind," interrogating her own agents in the dark.
+
 ## See also
+
+- [Mother Nocturne](people/mother-nocturne.md) — field commander (codename only).
+- Source: `dm-notes.docx` (Mother Nocturne / Night Mother passages); `faction-quests.xlsx`.

--- a/20-Factions/society-of-baldurian-integrity/README.md
+++ b/20-Factions/society-of-baldurian-integrity/README.md
@@ -5,3 +5,4 @@ Cultural-purity zealots warring against 'memetic contamination' from foreign art
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: calliope.

--- a/20-Factions/society-of-baldurian-integrity/people/README.md
+++ b/20-Factions/society-of-baldurian-integrity/people/README.md
@@ -1,0 +1,7 @@
+# Society of Baldurian Integrity — people
+
+Named figures.
+
+## Index
+
+- [calliope.md](calliope.md)

--- a/20-Factions/society-of-baldurian-integrity/people/calliope.md
+++ b/20-Factions/society-of-baldurian-integrity/people/calliope.md
@@ -1,0 +1,29 @@
+---
+name: calliope
+description: Failed Baldurian playwright turned Oath of Conspiracy paladin; leads a war against the "memetic contamination" of foreign art and ghosts.
+---
+
+# Calliope, the Silent Muse
+
+A former playwright and failed artist now leading a crusade against what she calls the city's "cultural contamination." An Oath of Conspiracy paladin and the founder of the [Society of Baldurian Integrity](../summary.md).
+
+## Manifesto
+
+> There is a form of magic no one talks about: memetic warfare. The unique, stubborn, and resilient spirit of Baldur's Gate is a kind of psychic entity, and foreign powers — Waterdeep and the Harpers chief among them — are trying to kill it. The clashing architectural styles aren't just ugly; they are sigils of chaos designed to disrupt the city's harmony. The ghostly lament in the Elfsong Tavern isn't a harmless haunting; it's a sonic plague instilling subconscious sadness and nostalgia for a time before the city was strong. The Circus of the Last Days is a beachhead for thought-forms from other realities to invade the populace's dreams. The goal is to make Baldurians forget who they are, making them placid consumers for foreign goods and ideas.
+
+## Backstory
+
+Calliope's magnum opus, "The Ballad of the Blushing Mermaid" — a play celebrating the city's roguish, independent spirit — was a colossal flop. It was overshadowed by a traveling troupe from Waterdeep performing elegant, sterile dramas. In her bitterness, Calliope had a revelation: her play didn't fail, it was *suppressed*. She began to see the pattern everywhere — the erosion of "true" Baldurian culture — and swore an oath to preserve the city's soul. She now wages war against the "pretty poisons" of foreign art.
+
+## Recent operations
+
+- Heckled a Waterdhavian bard at the Singing Lute; the public was unmoved.
+- Counter-memetic ballad at Wyrm's Crossing met with widespread ridicule.
+- Defaced new Waterdhavian statues in the Upper City with Baldurian mud and pamphlets — a small public win.
+- Followers captured during a midnight slogan raid on the Eastway mercenary barracks; she visited Heapside Prison disguised as a relative to deliver a coded cover story.
+- Ongoing: plans to invade the [Elfsong Tavern](../../) with enchanted tuning forks and replace its lament with a traditional Baldurian sea shanty.
+
+## See also
+
+- [Society of Baldurian Integrity](../summary.md) — the cell she founded.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `faction-quests.xlsx`.

--- a/20-Factions/society-of-baldurian-integrity/summary.md
+++ b/20-Factions/society-of-baldurian-integrity/summary.md
@@ -1,18 +1,41 @@
 ---
 name: society-of-baldurian-integrity
-description: Cultural-purity zealots warring against 'memetic contamination' from foreign art and architecture.
+description: Cultural-purity zealots waging "memetic counter-terrorism" against foreign art, architecture, and ghosts believed to be erasing Baldur's soul.
 ---
 
 # Society of Baldurian Integrity
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+A clandestine cell of cultural zealots who believe a coalition of foreign powers — chiefly Waterdeep and the [Harpers](../harpers/summary.md) — is using art, architecture, and stories as "memetic weapons" to erase the soul of Baldur's Gate. Founded and led by [Calliope, the Silent Muse](people/calliope.md).
 
 ## Ideology
 
+There is a form of magic no one talks about, the Society holds: "memetic warfare." The unique, stubborn spirit of Baldur's Gate is itself a kind of psychic entity, and foreign powers are trying to kill it. Clashing architectural styles aren't merely ugly; they are "sigils of chaos" disrupting the city's harmony. The Elfsong Tavern's lament is not a haunting but a "sonic plague" instilling subconscious sadness. The extraplanar [Carnival of Whispers](../carnival-of-whispers/summary.md) is a beachhead for thought-forms from other realities. The goal of the conspiracy: make Baldurians forget who they are so they become placid consumers for foreign goods and ideas.
+
 ## Membership
+
+Disgruntled local artists, fiercely nativist patriars from the [Patriar Heritage Society](../patriar-heritage-society/summary.md), tavern owners who only serve local ale, and young idealists convinced they are fighting for the city's very soul. The Society maintains a list of banned songs, architectural features marked for vandalism, and artists to be "re-educated."
 
 ## Methods
 
+- "Cultural counter-terrorism": heckling Waterdhavian bards (a public attempt at the Singing Lute went badly), splashing paint on Sembian-funded buildings, defacing Waterdhavian statues with Baldurian mud and pamphlets.
+- A planned defacement of an Amnian-funded mural in Heapside was ambushed by Coin-Swords acting on a paid informant.
+- A midnight raid to slogan-paint the mercenary barracks in Eastway ended with several followers captured by the Watch.
+- Under cover of debate at the High Hall, the Society held a chant of ancient Baldurian folk ballads outside the building, attempting to "psychically reinforce" the [Peerage of Blood](../peerage-of-blood/summary.md).
+- Ongoing: a sneak operation into the [Elfsong Tavern](../) with enchanted tuning forks to exorcise its "foreign ghost" and replace its lament with a traditional Baldurian sea shanty.
+- Calliope uses her paladin abilities to make people perceive the "hidden psychic barbs" in a sculpture or song.
+
 ## Hooks and Relationships
 
+**Conspiracy heart.** The [Waterdhavian Kontor](../waterdhavian-kontor/summary.md), believed to be coordinating the memetic invasion.
+
+**Suspected agents.** The [Harpers](../harpers/summary.md), whom Calliope believes are the conspiracy's covert operatives.
+
+**Targets.** The [Carnival of Whispers](../carnival-of-whispers/summary.md) (treated as an extraplanar invasion), any non-Baldurian artist, and the Elfsong Tavern itself.
+
+**Captured followers.** Several members are now in Heapside Prison after the failed barracks raid; Calliope has visited under cover, instructing them to claim they were drunken vandals paid by a merchant.
+
 ## See also
+
+- [Calliope, the Silent Muse](people/calliope.md) — leader.
+- [Patriar Heritage Society](../patriar-heritage-society/summary.md) — overlapping nativist current.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Secret Factions › The Conspiracists); `faction-quests.xlsx`.

--- a/20-Factions/takers-of-the-tithe/README.md
+++ b/20-Factions/takers-of-the-tithe/README.md
@@ -5,3 +5,4 @@ Reaper-cult assassins claiming master artisans as a 'tithe' to their patron.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [people/](people/) — Named figures: the-collector.

--- a/20-Factions/takers-of-the-tithe/people/README.md
+++ b/20-Factions/takers-of-the-tithe/people/README.md
@@ -1,0 +1,7 @@
+# The Takers of the Tithe — people
+
+Named figures.
+
+## Index
+
+- [the-collector.md](the-collector.md)

--- a/20-Factions/takers-of-the-tithe/people/the-collector.md
+++ b/20-Factions/takers-of-the-tithe/people/the-collector.md
@@ -1,0 +1,29 @@
+---
+name: the-collector
+description: Anonymous leader of the Takers of the Tithe; communicates with followers only through skeletal messengers.
+---
+
+# The Collector
+
+Codename of the founder of the [Takers of the Tithe](../summary.md). Identity unknown — rumored to be a minor patriar with a family history steeped in necromancy, or a surviving priest from Myrkul's ancient clergy. The Collector communicates with the cult's hunting parties only through written messages delivered by skeletal messengers, maintaining absolute anonymity.
+
+## Manifesto
+
+> The city teems with life. A chaotic, squirming mass of flesh. But life is not a right; it is a debt owed to death. Most souls are a pittance, a copper coin tossed into a void. But some… some shine. The soul of a hero, a master artisan, a peerless musician. These are the platinum pieces. We are the Takers. We collect the tithe for a king long forgotten. We will re-assemble his treasury, and with a hundred perfect souls, we will buy his return.
+
+## Operational doctrine
+
+- Hunting parties of three: **Spotter**, **Reaper**, **Keeper**. Spotter identifies, Reaper kills with a soul-trapping weapon, Keeper guards the gem.
+- Cell-leaders styled "**The Bishop**" receive target names by Bhaalist revelation.
+- Murder is framed as "debt collection"; the cult runs a literal **Tithe Ledger** documenting kills and patriar payments. The ledger has been compromised by adventurers.
+
+## Recent operations
+
+- Failed assassination of master goldsmith **Elara Varrin** ([Worshipful Company of Goldsmiths & Jewelers](../../wc-goldsmiths-jewelers/summary.md) hardened her detail).
+- Designated **The Ember** (Alfira, [Followers of the Phoenix](../../followers-of-the-phoenix/summary.md)) the next high-value target. The Reaper's strike at the Phoenix Gate failed; the assassin was captured by refugee militia. The Collector dispatched a follow-up assassin who was driven off by Hellrider hounds, then paid a corrupt stockade guard to feed the captured Reaper a necrotic poison — silencing him for good.
+- After the loss of Singa and the Tithe Ledger, the Collector dispatched a Hunter-Killer cell into Rivington to eliminate the adventurers responsible.
+
+## See also
+
+- [The Takers of the Tithe](../summary.md) — the cult he runs.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx`; `dm-notes.docx`; `faction-quests.xlsx`.

--- a/20-Factions/takers-of-the-tithe/summary.md
+++ b/20-Factions/takers-of-the-tithe/summary.md
@@ -1,18 +1,38 @@
 ---
 name: takers-of-the-tithe
-description: Reaper-cult assassins claiming master artisans as a 'tithe' to their patron.
+description: Elite Bhaalist death-cult that hunts the city's most exceptional souls as a "tithe" intended to fund the resurrection of Myrkul.
 ---
 
 # The Takers of the Tithe
 
-_(stub — fill from `raw-ingest/cloaks-and-conspiracies/factions.docx` and the public-factions paste at `.context/attachments/`.)_
+An elite death-cult that stalks and murders the city's most exceptional individuals. Operationally a Bhaalist hunter-killer outfit; theologically devoted to **Myrkul**, the original Lord of the Dead. Led from the shadows by ["The Collector"](people/the-collector.md), an anonymous figure who communicates with followers only through skeletal messengers.
 
 ## Ideology
 
+The Takers hold that Bhaal's resurrection was a crude rehearsal, and that Myrkul — the true master of the dead — was always the higher mystery. A soul, in their cosmology, is a coin: most are pittance, but some shine. With enough platinum-grade soul-coins they will buy their master's return.
+
 ## Membership
+
+Cultists work in hunting parties of three: a **Spotter** identifies and shadows the target, a **Reaper** kills with a soul-trapping weapon, and a **Keeper** guards the captured soul gem. Above them sits a cell-leader called "**The Bishop**" who receives target names by Bhaalist revelation. The Collector is rumored to be either a minor patriar of necromantic descent or a survivor of Myrkul's ancient clergy. Murder is framed as "debt collection"; the cult keeps a literal **Tithe Ledger**. (See [The Collector](people/the-collector.md) for the full manifesto.)
 
 ## Methods
 
+- Methodical multi-week stalking, then a clean kill with a soul-trapping weapon.
+- Failed attempt on master goldsmith **Elara Varrin** — bodyguards drove off the Reaper; she is now under the [Worshipful Company of Goldsmiths & Jewelers](../wc-goldsmiths-jewelers/summary.md)' protection.
+- Pivoted to **The Ember** (Alfira) of the [Followers of the Phoenix](../followers-of-the-phoenix/summary.md). The Phoenix Gate strike failed; the Reaper was captured by refugees. A follow-up assassin was driven off; a corrupt stockade guard was then paid to feed the prisoner necrotic poison, silencing him for good — his soul trapped in a gem and smuggled out.
+- The **Tithe Ledger** documenting patriar payments was lost to adventurers, escalating the cult to "Tier-1 threat" status against them.
+- A Hunter-Killer cell now hunts those adventurers in Rivington.
+
 ## Hooks and Relationships
 
+**Targets en masse.** Worshipful Company Masters, the leadership of the [Sorcerous Sodality](../wc-sorcerous-sodality/summary.md), and famous adventurers — anyone whose soul "shines."
+
+**Patron tension.** Officially Myrkul's, operationally Bhaal's; allied with the [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) and **Singa's** cell of the [Plague of Remembrance](../plague-of-remembrance/summary.md). The Dead Three's classic factionalism is their greatest weakness.
+
+**Specific targets.** Elara Varrin (goldsmith); The Ember of the [Followers of the Phoenix](../followers-of-the-phoenix/summary.md). The [Guild](../guild/summary.md) treats the Takers as both rivals and a quiet contract market for "platinum-soul" hits.
+
 ## See also
+
+- [The Collector](people/the-collector.md) — anonymous leader.
+- [Cult of the Returning Lord](../cult-of-the-returning-lord/summary.md) — operational ally.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Cults › The Takers of the Tithe); `dm-notes.docx`; `faction-quests.xlsx`.


### PR DESCRIPTION
## Summary

Closes #17. Replaces stub `summary.md` files and adds leader pages for the remaining 13 secret/cult/party folders under `20-Factions/` — three Conspiracy Cells, nine Cults, and the Party — synthesizing material from `factions.docx`, `dm-notes.docx`, `faction-quests.xlsx`, and the fey-courts dossier. Codename leader files (`the-voice`, `the-collector`, `the-bhaal-celebrant`, `mother-nocturne`, `the-ember`) are used where the source names no individual; `unveiled/` is left untouched as the worked example, and `party/summary.md` stays in placeholder form pending session 0.

## Test plan

- [ ] All 13 `summary.md` files contain full prose (no stub line) and are under 500 words.
- [ ] Each leader page exists where the source names a leader; codename pages used otherwise.
- [ ] `uv run python src/ingest/scaffold_factions.py` produces no further diffs.
- [ ] `20-Factions/README.md` still lists all 13 in their respective sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)