### PR TITLE
Ingest Baldur's Gate 1502 DR dossier across the knowledge base (#19)

### DIFF
--- a/00-Campaign-Frame/README.md
+++ b/00-Campaign-Frame/README.md
@@ -4,4 +4,6 @@ Evergreen rules of the world: the "physics," the psychology, and the psychosis u
 
 ## Index
 
-_(empty — populate as files are added)_
+- [economics.md](economics.md) — money is the blood; debt is the chain. The economic physics.
+- [power.md](power.md) — patchwork sovereignty, contractual jurisdiction, mutual leverage.
+- [class-and-survival.md](class-and-survival.md) — the Wretched-to-Aristocratic ladder is a literal agency ladder.

--- a/00-Campaign-Frame/class-and-survival.md
+++ b/00-Campaign-Frame/class-and-survival.md
@@ -1,0 +1,37 @@
+---
+name: class-and-survival
+description: The Wretched-to-Aristocratic ladder; daily-cost reality maps directly onto agency.
+---
+
+# Class and Survival
+
+> What you can afford to do tomorrow is what you can afford to eat today.
+
+A working principle. The campaign's lifestyle tiers (`Wretched → Aristocratic`, see [10-Setting/economy/cost-of-living.md](../10-Setting/economy/cost-of-living.md)) are not flavor — they are a literal agency ladder.
+
+## The principle
+
+In this world, **survival cost is the floor of agency**. A person whose daily income is consumed by lodging and food has no surplus for anything else: travel, a Worshipful Company apprenticeship fee, a bribe, a sword, a healer, hope. The lifestyle table is therefore not a price list — it is a description of *how much of yourself you have left at the end of a day*.
+
+The Council did not invent this ladder. The Decade of Reconstruction made it legible by stratifying the city into districts that match their tier. The Wretched live in the Outer City and the Floodway. The Aristocrats live in Manorborn. The space between is the city.
+
+## Three corollaries
+
+**1. Class is geographic.** Where you sleep tells everyone what you can do. A Lower City modest address marks you as someone with options; a Wyrm's Crossing flophouse marks you as someone hoping to leave; an Upper City manor marks you as someone whose decisions move other people's lives by default.
+
+**2. Mobility is a campaign event, not a default.** Climbing one tier is months or years of paid labor *plus* the absence of a single setback (a fine, an illness, a fire, a Worshipful Company audit). Climbing two tiers usually requires a patron, a windfall, or a corpse — which is why so many people try adventuring. The Decade of Reconstruction window has effectively closed for newcomers.
+
+**3. Agency aggregates upward.** A wretched person can affect their block. An aristocrat can affect a vote in the High Hall. *Every tier above you can override every tier below you, by default.* The Guild's structural innovation was inverting this — aggregating wretched and poor loyalty into a bloc large enough to negotiate with aristocrats. That is why it terrifies the Council.
+
+## What this means at the table
+
+- Lifestyle tier is a *budget*, not a costume. A modest-tier PC who spends like a comfortable-tier PC is mortgaging tomorrow's meals.
+- "Slumming" is visible. An aristocrat in the Floodway draws the same kind of attention a beggar in the Helm and Cloak does — they are out of place on the ladder, and someone will charge them for it.
+- NPC reactions track tier as much as faction. The Watch's politeness scales with your visible wealth. That is the operating system, not anyone's character flaw.
+- Crossing tiers in either direction is a *story*. The lifestyle table is plot scaffolding.
+
+## See also
+
+- [economics.md](economics.md) — what the ladder is built of.
+- [power.md](power.md) — what it grants access to.
+- [10-Setting/economy/cost-of-living.md](../10-Setting/economy/cost-of-living.md) — the numbers.

--- a/00-Campaign-Frame/economics.md
+++ b/00-Campaign-Frame/economics.md
@@ -1,0 +1,35 @@
+---
+name: economics
+description: Money is the blood of the world; debt is the chain that binds it. The campaign's economic physics.
+---
+
+# Economics
+
+> Money is the blood of the world; debt is the chain that binds it.
+
+A working principle distilled from the dossier — not a description of a market but a rule of how power, agency, and survival actually move in this world.
+
+## The principle
+
+In this campaign, **wealth is not a measure of success — it is the substrate of action**. A person without coin has no agency they did not borrow from someone with coin. A faction without revenue has no policy it did not buy from a faction with revenue. The Council debates public works on return on investment because that is the only language treaties, charters, and laws are written in.
+
+This is not corruption. It is the operating system. The moralizing language — "buying influence," "votes for sale" — is what people who lost the bidding war say afterward.
+
+## Three corollaries
+
+**1. Debt outlives the debtor.** A loan from the Gold-Gable Hall is enforceable across the Sword Coast Hansa. A favor owed to a Ward Boss outlives the Ward Boss; their Sachem inherits the ledger. A pact with a devil through the Knights of the Shield outlives the soul that signed it. The chain is the part that matters.
+
+**2. Sovereignty is liquid.** The Great Bargain proved that a city can sell pieces of its own jurisdiction for cash. The Foreign Kontors are sovereign because they paid for sovereignty and the receipts are filed. The Outer City is unwalled because no one paid to wall it. The K'liir is autonomous because the Council cannot afford to take it. *Where the money is not, the law is not.*
+
+**3. Patronage is the only welfare state.** The Council abandoned the common citizen to high finance and trade. The Guild filled the gap by *buying* loyalty: jobs, medicine, firewood, school for a Ward Boss's nephew. The Hellriders feed New Elturel because the Council does not. The Worshipful Companies care for sick guild members because the Companies own the only insurance contract that pays. Every social safety net in this world is somebody's investment.
+
+## What this means at the table
+
+- A character without resources has no purchase on the world. Adventuring is one of the few legitimate accelerants out of poverty — which is why so many try it and die doing it.
+- A faction's *budget* tells you more about its real plans than its stated ideology.
+- Debt is a story engine. Who do you owe? Who do they owe? The chain ends at someone with a Council seat or a Kontor charter.
+- Wealth is conspicuously moral here. The aristocratic lifestyle is *legible* as power; the wretched lifestyle is *legible* as voicelessness.
+
+## Source
+
+Distilled from dossier Chapters 1, 7, 8, 9.

--- a/00-Campaign-Frame/power.md
+++ b/00-Campaign-Frame/power.md
@@ -1,0 +1,40 @@
+---
+name: power
+description: Power in this world is brokered through legal jurisdictions, private guards, and mutual leverage; no single sovereign claim wins outright.
+---
+
+# Power
+
+> Authority in Baldur's Gate does not flow from a throne. It is negotiated at the gates.
+
+A working principle. Not a description of who rules but of how rule itself functions.
+
+## The principle
+
+There is no single sovereign in this world. There is a **patchwork of overlapping jurisdictions**, each of which holds final authority within its own domain and *negotiated* authority everywhere else. A street brawl can cross four jurisdictions in a hundred feet — Watch, Flaming Fist, Worshipful Company Wardens, Kontor guards — and which one shows up first determines how the case is filed, or whether it is filed at all.
+
+This is the rule of law in Baldur's Gate. Not that there is no law, but that **there are too many laws, and they apply to different people in the same place at the same time.**
+
+## Three corollaries
+
+**1. Sovereignty is geographic and contractual, not territorial.** A Foreign Kontor is sovereign within its walls because its charter says so. A Company Warden is sovereign over a guild member *anywhere* because the Company's charter says so. The Guild rules the Lower City sewers because no one can take them. Sovereignty is whatever a counterparty cannot afford to challenge.
+
+**2. Every authority is also a vendor.** The Flaming Fist polices, but the Watch polices better — for a fee. The Worshipful Company sets quality standards, but they also enforce monopoly pricing. The Council ratifies legislation, but its members also represent the consortiums whose legislation they ratify. The line between regulator and regulated is not blurred — it has been deliberately erased.
+
+**3. No one wins outright.** Any faction strong enough to dominate provokes a coalition against itself. The Patriar Heritage Society lost to the consortiums but kept the Peerage of Blood. The Guild owns the streets but cannot take the High Hall. The Foreign Kontors hold the docks but cannot break the Companies' Wardens. *Mutual leverage* is the equilibrium — not by design, but because every attempt to break it has failed.
+
+## What this means at the table
+
+- *Jurisdictional standing* matters as much as raw power. A Company seal opens doors a sword cannot; a Ward Boss's nod ends arguments a Council writ cannot.
+- "Who do I appeal to?" is the wrong question. Ask "Whose jurisdiction is this, and what do they want?" — sometimes three answers apply at once.
+- Threatening someone means threatening their *patrons*. Killing a Ward Boss invites a Sachem's reprisal; embarrassing a Council member invites their consortium's lawyers.
+- Reform is structurally hard. Every dysfunction has constituents. The Great Bargain is unjust *and* indispensable.
+
+## See also
+
+- [economics.md](economics.md) — the resource layer beneath all of this.
+- [class-and-survival.md](class-and-survival.md) — the human ladder this power patchwork lands on.
+
+## Source
+
+Distilled from dossier Chapters 4, 5, 6, 12.

--- a/10-Setting/CONTRIBUTING.md
+++ b/10-Setting/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+---
+name: setting-contributing
+description: Layout convention for the Setting folder.
+---
+
+# Contributing — Setting
+
+## Layout
+
+```
+history/         # dated events at world-visible scale; per-event files when warranted
+polities/        # institutional frameworks (alliances, government systems)
+peoples/         # demographic groups and diasporas
+economy/         # cost-of-living, market mechanics, commercial reference
+cosmology.md     # planar / divine framework when needed
+```
+
+## Boundary with neighbors
+
+- **40-Timeline/** owns the canonical chronology and per-week event files. `10-Setting/history/` holds the *story* of an event (causes, consequences, structure); `40-Timeline/` holds the *date* and the one-line summary.
+- **30-Places/** owns geography. Setting describes the institution; Places describes the building it occupies.
+- **20-Factions/** owns prose for a faction. Setting describes the *system* a faction belongs to (e.g., the Worshipful Company framework lives here; each WC's character lives in its faction folder).
+
+## Conventions
+
+- Each markdown file under 500 words.
+- Frontmatter on every content file: `name` + `description`.
+- Per-folder `README.md` indexes its contents.

--- a/10-Setting/README.md
+++ b/10-Setting/README.md
@@ -1,7 +1,17 @@
+---
+name: setting
+description: Cosmology, major conflicts, historical timeline, and the psyche of the world.
+---
+
 # Setting
 
 Cosmology, major conflicts, historical timeline, and the psyche of the world. Grounding context that anchors events and motivations.
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the layout convention.
+
 ## Index
 
-_(empty — populate as files are added)_
+- [history/](history/README.md) — dated events at world-visible scale; the foundational catastrophes and reformations.
+- [polities/](polities/README.md) — institutional frameworks: trade alliances, governing systems, guild structures.
+- [peoples/](peoples/README.md) — diasporas and demographic groups.
+- [economy/](economy/README.md) — cost-of-living and commercial reference.

--- a/10-Setting/economy/README.md
+++ b/10-Setting/economy/README.md
@@ -1,0 +1,12 @@
+---
+name: setting-economy
+description: Cost-of-living and commercial reference for the Sword Coast.
+---
+
+# Economy
+
+Commercial reference. The campaign-frame distillation of *what money means* lives in [00-Campaign-Frame/economics.md](../../00-Campaign-Frame/economics.md).
+
+## Index
+
+- [cost-of-living.md](cost-of-living.md) — lifestyle tiers and the Baldurian's ledger of typical prices.

--- a/10-Setting/economy/cost-of-living.md
+++ b/10-Setting/economy/cost-of-living.md
@@ -1,0 +1,57 @@
+---
+name: cost-of-living
+description: Lifestyle tiers and reference prices for goods and services in Baldur's Gate, 1502 DR.
+---
+
+# Cost of Living
+
+Reference table. The thematic reading — *what money does in this world* — lives in [00-Campaign-Frame/economics.md](../../00-Campaign-Frame/economics.md) and [00-Campaign-Frame/class-and-survival.md](../../00-Campaign-Frame/class-and-survival.md).
+
+## Lifestyle tiers (per day)
+
+| Tier | Cost/day | Who lives here | What you get |
+| --- | --- | --- | --- |
+| Wretched | Free – 1 sp | Outer City beggars, Undercity dwellers | Lean-to, scavenged food |
+| Squalid | 1–2 sp | New Elturel refugees, unemployed laborers | Cot in tenement dorm; gruel |
+| Poor | 2–5 sp | Dockworkers, apprentices | Shared room; two simple meals |
+| Modest | 1–2 gp | Journeymen, Fist privates, merchant clerks | Private small room; tavern ale |
+| Comfortable | 8–15 gp | Successful merchants, junior officers | Townhouse; fine clothes; entertainment |
+| Wealthy | 50–100 gp | Guild Masters, senior Kontor officials, minor patriars | Upper City home; servants; political access |
+| Aristocratic | 250+ gp | Major patriars, consortium heads | Manor; full staff; private guards; influence |
+
+A small house in the Lower City sells for **2,000–5,000 gp**, but renting is far more common.
+
+## The Baldurian's ledger
+
+Prices reflect the Worshipful Companies' chartered monopolies and the Kontors' specialized trade.
+
+### Lodging
+
+| Item | Cost | Where |
+| --- | --- | --- |
+| Squalid flophouse cot | 2 sp | Fraygo's (Wyrm's Crossing) |
+| Modest inn room | 1 gp | Elfsong Tavern (Lower City) |
+| Wealthy suite | 15 gp | Splendid Yard (Waterdhavian Kontor) — Alliance credentials only |
+| Aristocratic suite | 40 gp | Helm and Cloak (Upper City) — by invitation |
+
+### Food, drink, equipment
+
+| Item | Cost | Notes |
+| --- | --- | --- |
+| Mug of common ale | 4 cp | Vintners' Company license |
+| Bottle of fine Amnian wine | 50 gp | 40 gp direct from the Gold-Gable Hall |
+| Day's rations | 5 sp | Beehive General Goods |
+| 50 ft. silk rope | 10 gp | Standard |
+| Plate armor | 2,500 gp | Forge of the Nine; Smiths' Company seal required |
+| Vial of antitoxin | 75 gp | Crimson Draughts; Alchemists' Company price |
+| Smokepowder keg | 1,000 gp | Cogwork Quay; sale restricted and monitored |
+
+### Services
+
+| Service | Cost | Notes |
+| --- | --- | --- |
+| Spellcasting (1st level) | 75–150 gp | Sorcerous Sodality; unlicensed casting is a serious crime |
+| Skilled mercenary | 100 gp/day | Iron Ledger; contract registered with the Kontor |
+| Smuggling passage | 800 gp | Guild via a Ward Boss; bypasses Fist customs |
+| Information (minor secret) | 200–1,000 gp | Guild informant or the Bibliophile; price scales with target |
+

--- a/10-Setting/history/1497-reformation.md
+++ b/10-Setting/history/1497-reformation.md
@@ -1,0 +1,33 @@
+---
+name: 1497-reformation
+description: 1497 DR — Parliament restructured into Peerages of Blood and Coin, formalizing the plutocracy.
+---
+
+# The Parliament Reformation (1497 DR)
+
+The political settlement that followed the [Great Bargain's](great-bargain.md) economic one. After this date, Baldur's Gate was, in formal law as well as practice, a plutocracy.
+
+## What changed
+
+The [Parliament of Peers](../../20-Factions/parliament-of-peers/summary.md) was expanded to **100 seats** and split into two functionally bicameral chambers:
+
+- **The Peerage of Blood (50 seats).** Hereditary right of the fifty wealthiest patriar families. A concession to tradition. Critically, eligibility to *sit* still belongs to those families, but **confirmed citizens of every type inside the walls now carry a vote** for who fills the seat. This was a radical concession that for the first time tied patriar political fate to the Lower City — a leverage point [The Guild](../../20-Factions/guild/summary.md) has exploited masterfully.
+- **The Peerage of Coin (50 seats).** Allocated to the largest economic entities in the city, with the number of seats per faction recalculated annually based on tax receipts. Kontors, Consortiums, and the largest Worshipful Companies trade seats every fiscal year. The chamber is fiercely competitive.
+
+Bills must pass both chambers before [Council of Four](../../20-Factions/council-of-four/summary.md) ratification.
+
+## What it formalized
+
+- **Votes are commodities.** A seat in the High Hall is no longer a matter of birthright alone; it can be purchased — by accumulating tax-paying scale.
+- **The Archduke seat follows the money.** The Archduke is the Duke whose affiliated economic bloc contributed the most to the city's coffers in the previous fiscal year. Currently **Lyra Silvershield** of the Western Gate Trading Company.
+- **Permanent two-house tension.** The conservative, tradition-bound Blood chamber against the aggressive, profit-driven Coin chamber. Patriar grievance is now structural, not just nostalgic.
+
+## Why it stuck
+
+The Reformation was sold as a means of binding ascendant economic powers into formal accountability — paying for the city by *being seated* in it. In practice it gave the Kontors and the Consortiums what they already had economically, in writ. Reversing it would require a coalition the patriars cannot assemble without the Lower City — which the Guild now effectively delivers, and which the patriars cannot court without forfeiting the very privileges they want to restore.
+
+## See also
+
+- [Decade of Reconstruction](decade-of-reconstruction.md) — the full 1492–1502 arc this sits inside.
+- [Council of Four](../../20-Factions/council-of-four/summary.md) — executive successor body.
+- [Patriar Heritage Society](../../20-Factions/patriar-heritage-society/summary.md) — the Blood chamber's organized voting bloc.

--- a/10-Setting/history/README.md
+++ b/10-Setting/history/README.md
@@ -1,0 +1,15 @@
+---
+name: setting-history
+description: World-fact history files; dated chronology lives in 40-Timeline.
+---
+
+# History
+
+World-visible historical events at the *story* level — causes, structure, consequences. The dated chronology lives in [40-Timeline/](../../40-Timeline/README.md).
+
+## Index
+
+- [absolute-crisis.md](absolute-crisis.md) — 1492 DR; the Netherbrain and the foundational catastrophe of the present age.
+- [decade-of-reconstruction.md](decade-of-reconstruction.md) — 1492–1502 DR rebuild; defines the present city's character.
+- [great-bargain.md](great-bargain.md) — 1493 DR; the post-crisis charter that birthed the Foreign Kontors.
+- [1497-reformation.md](1497-reformation.md) — Parliament restructure that created the Peerage of Coin.

--- a/10-Setting/history/absolute-crisis.md
+++ b/10-Setting/history/absolute-crisis.md
@@ -1,0 +1,37 @@
+---
+name: absolute-crisis
+description: 1492 DR — the Cult of the Absolute and the Netherbrain nearly conquered Baldur's Gate.
+---
+
+# The Absolute Crisis (1492 DR)
+
+The foundational catastrophe of the present age and the prime mover of every institution rebuilt since.
+
+## What happened
+
+The **Cult of the Absolute**, secretly masterminded by the Chosen of the Dead Three (Bane, Myrkul, Bhaal — represented by Gortash, Ketheric Thorm, and Orin) and a captive **Netherbrain**, attempted to conquer Baldur's Gate. The plan was ceremorphic: convert the city's leadership and population into mind flayers under the Brain's control, then expand outward across Faerûn.
+
+The city was nearly destroyed. The Brain was destroyed by a small band of heroes in the Heapside / Eastway districts; the surviving Cult leadership scattered or died. Grand Duke **Ulder Ravengard**, captured and indoctrinated, was rescued but politically compromised; the rest of the Council was vacant or tainted.
+
+## Why it matters
+
+The Absolute Crisis is not a distant memory. It is the trauma that shaped every subsequent civic decision:
+
+- The **Great Bargain** ([→](great-bargain.md)) was justified as a response to the bankrupt treasury and shattered infrastructure.
+- The **Decade of Reconstruction** ([→](decade-of-reconstruction.md)) defined the rebuilt city's pale-stone-on-soot architecture.
+- The **Parliament Reformation of 1497** ([→](1497-reformation.md)) was sold as a way to bind ascendant economic powers into formal accountability.
+- The **Flaming Fist's** decline began here; the Cult's infiltration of the Fist's command discredited it for a decade.
+
+## Who the heroes were
+
+The party of adventurers credited with destroying the Brain dispersed immediately:
+
+- **Karlach** and **Wyll** descended into Avernus to wage war against the Archdevil Zariel.
+- **Prince Orpheus** returned to the Astral Plane to ignite a rebellion against the Lich-Queen Vlaakith — though a faction of his loyalists, under **K'laar the Unshackled**, settled in Baldur's Gate's Outer City as the K'liir.
+- Others vanished into legend.
+
+This is why the post-crisis city had to save itself: the heroes had not stayed.
+
+## Lingering threats
+
+Remnant cults persist. The [Cult of the Returning Lord](../../20-Factions/cult-of-the-returning-lord/summary.md) (Bhaal), the [Silent Shroud](../../20-Factions/silent-shroud/summary.md) (Shar), and the [Hands of the Absolute](../../20-Factions/hands-of-the-absolute/summary.md) (True Soul splinters) all trace lineage to this period and still operate. The **Steel Watch Foundry** (Gray Harbour) and certain sealed Heapside cellars are quietly cordoned by the Fist for related reasons.

--- a/10-Setting/history/decade-of-reconstruction.md
+++ b/10-Setting/history/decade-of-reconstruction.md
@@ -1,0 +1,35 @@
+---
+name: decade-of-reconstruction
+description: 1492–1502 DR — the frantic, brutal rebuild that produced the present city.
+---
+
+# The Decade of Reconstruction (1492–1502 DR)
+
+The ten years that followed the Absolute Crisis were not a period of quiet healing. They were a frantic, often brutal transformation.
+
+## Phase 1 — The immediate aftermath (late 1492 – 1493 DR)
+
+A city teetering on collapse. The [Council of Four](../../20-Factions/council-of-four/summary.md) was in shambles; the [Flaming Fist](../../20-Factions/flaming-fist/summary.md) was decimated and politically discredited; tens of thousands of refugees poured into the **Outer City**.
+
+An informal **Emergency Council** of survivors took de facto control: remnants of the [Parliament of Peers](../../20-Factions/parliament-of-peers/summary.md), the suddenly indispensable Guildmaster **Nine-Fingers Keene** (whose network kept order in the Lower and Outer Cities), and newly ascendant merchant masters whose fortunes had survived intact.
+
+## Phase 2 — The Great Bargain (1493–1495 DR)
+
+Faced with shattered infrastructure, a bankrupt treasury, and a humanitarian crisis, the Emergency Council made a series of momentous decisions known as **The Great Bargain** ([→](great-bargain.md)). It traded long-term sovereignty for short-term survival by chartering the **Foreign Kontors**.
+
+## Phase 3 — Rise of the Consortiums (1495–1498 DR)
+
+The influx of foreign capital and the hyper-competitive Kontor environment forced rapid evolution in native economic structures. Old loosely affiliated merchant guilds and trading **costers** (Seven Suns, Iron Throne, High Moon) could not compete and consolidated into larger, more aggressive **Merchant Consortiums** modeled on their foreign counterparts. Two emerged dominant: the [Chionthar Consortium](../../20-Factions/chionthar-consortium/summary.md) and the [Western Gate Trading Company](../../20-Factions/western-gate-trading-company/summary.md).
+
+In 1497, the Parliament was officially reformed — see [1497-reformation.md](1497-reformation.md).
+
+## Phase 4 — The Outer City coalesces (1496–1502 DR)
+
+Two settlements outside the walls became permanent polities-in-miniature:
+
+- **The K'liir** — established 1496 by githyanki loyal to Prince Orpheus under **K'laar the Unshackled**; an enclave of astral architecture and alien technology.
+- **New Elturel** — coalesced from the Elturian refugee shantytowns south of the river; developed informal Hellrider governance, a fierce shared-trauma identity, and piety centered on Torm, Ilmater, and Lathander.
+
+## What it produced
+
+By 1502 DR, Baldur's Gate is the rebuilt commercial hub of the [Sword Coast Hansa](../polities/sword-coast-hansa.md), a working plutocracy where votes in the High Hall are commodities. The city is louder, richer, more vibrant, and more vulnerable than it has ever been. The architectural signature — pale clean stone next to soot-stained pre-crisis facades — is the visible mark of the decade. The political signature is the [Peerage of Coin](../../20-Factions/peerage-of-coin/summary.md) seated next to the [Peerage of Blood](../../20-Factions/peerage-of-blood/summary.md).

--- a/10-Setting/history/great-bargain.md
+++ b/10-Setting/history/great-bargain.md
@@ -1,0 +1,34 @@
+---
+name: great-bargain
+description: 1493 DR — the post-crisis charter that traded sovereignty for capital and birthed the Foreign Kontors.
+---
+
+# The Great Bargain (1493 DR)
+
+The Emergency Council's most consequential act. A staggering concession of sovereignty in exchange for the gold needed to rebuild.
+
+## The deal
+
+Unable to fund reconstruction internally, the Emergency Council sent emissaries to the great mercantile city-states of the Sword Coast and beyond — **Amn**, **Waterdeep**, **Sembia**, and (later) **Lantan**. The offer was unprecedented: in exchange for massive immediate infusions of gold, materials, and skilled labor, these foreign powers would be granted charters to establish self-governing commercial enclaves — **Kontors** — on prime real estate within the Lower City.
+
+## Terms
+
+Each Kontor:
+
+- Operates under the laws of its home nation, not Baldurian law (extraterritoriality).
+- Maintains its own private armed force, jurisdictionally sovereign within its walls.
+- Pays a **fixed long-term tax** to the city treasury *in lieu of* normal tariffs and duties.
+- Holds a perpetual lease on its land.
+
+The four chartered Kontors are the [Amnian Kontor](../../20-Factions/amnian-kontor/summary.md) (Gold-Gable Hall), the [Waterdhavian Kontor](../../20-Factions/waterdhavian-kontor/summary.md) (Splendid Yard), the [Sembian Kontor](../../20-Factions/sembian-kontor/summary.md) (Iron Ledger), and the [Lantaner Concession](../../20-Factions/lantaner-concession/summary.md) (Cogwork Quay).
+
+## Consequences
+
+- **Capital flooded in.** The city was rebuilt on schedule.
+- **Sovereignty fractured.** Crime committed inside a Kontor falls under that Kontor's jurisdiction, even when the perpetrator or victim is Baldurian. A simple street brawl that crosses a Kontor wall can become an international incident.
+- **The native economy was forced to consolidate.** Old costers and loose merchant guilds could not compete with Kontor scale; they merged into the modern **Merchant Consortiums** during the next phase of the [Decade of Reconstruction](decade-of-reconstruction.md).
+- **The political settlement followed the economic one.** By 1497 the Parliament was formally restructured to seat the Kontors and their consortium imitators ([→](1497-reformation.md)).
+
+## Friction it left behind
+
+The Bargain is the source of every modern Baldurian grievance about foreign influence. The [Patriar Heritage Society](../../20-Factions/patriar-heritage-society/summary.md) wants it rolled back. The [Chionthar Consortium](../../20-Factions/chionthar-consortium/summary.md) and the [Western Gate Trading Company](../../20-Factions/western-gate-trading-company/summary.md) exist primarily to compete with it. Conspiracy cells like [The Purified](../../20-Factions/purified/summary.md) and the [Society of Baldurian Integrity](../../20-Factions/society-of-baldurian-integrity/summary.md) treat the Kontors as an ongoing slow-motion conquest.

--- a/10-Setting/peoples/README.md
+++ b/10-Setting/peoples/README.md
@@ -1,0 +1,12 @@
+---
+name: setting-peoples
+description: Diasporas and demographic groups across the Sword Coast.
+---
+
+# Peoples
+
+Demographic groups whose identity, history, and politics span beyond a single place.
+
+## Index
+
+- [elturian-diaspora.md](elturian-diaspora.md) — the survivors of the Fall of Elturel; concentrated in New Elturel.

--- a/10-Setting/peoples/elturian-diaspora.md
+++ b/10-Setting/peoples/elturian-diaspora.md
@@ -1,0 +1,38 @@
+---
+name: elturian-diaspora
+description: The survivors of the Fall of Elturel (1494 DR), now a defining political bloc in Baldur's Gate.
+---
+
+# The Elturian Diaspora
+
+The Fall of Elturel in 1494 DR — when the capital of Elturgard vanished from the Material Plane, dragged into Avernus by the Archdevil Zariel — created the largest single refugee movement on the Sword Coast in living memory. Thousands of survivors flocked to Baldur's Gate, the perceived safety of the largest nearby city. The city absorbed them; the city has not finished metabolizing them.
+
+## Who they are
+
+- **Tieflings.** Disproportionately represented (Elturel's population skewed tiefling before the Fall, and many of those who survived Avernus came back marked). The population swelled the Gate's tiefling demographic from a small minority to roughly 8% of the total city.
+- **Mortal humans of the old Elturgard.** Farmers, clerics, craftspeople, soldiers — the social cross-section of a fallen kingdom.
+- **Hellrider veterans.** The remnants of Elturel's volunteer cavalry, now a militia and informal government for **New Elturel**. See [Hellriders of New Elturel](../../20-Factions/hellriders-of-new-elturel/summary.md).
+
+## Where they live
+
+Concentrated in **New Elturel** (Outer City, south bank), with smaller communities scattered through Twin Songs, Norchapel, and Rivington. See [30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md](../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md).
+
+## Identity
+
+Forged in shared trauma. A fierce, desperate piety centered on gods of hope and endurance — primarily **Torm**, **Ilmater**, and **Lathander**. Elturians read their survival as a covenant: they did not die in Avernus, so they owe the living. In practice this manifests as community organization, mutual aid, and a deep skepticism of any authority that did not come for them when Elturel fell.
+
+## Political weight
+
+A large, unified, residentially-clustered population is — in the post-1497 electoral mathematics of the [Peerage of Blood](../../20-Factions/peerage-of-blood/summary.md) — a major voting bloc. The [Hellriders](../../20-Factions/hellriders-of-new-elturel/summary.md) lobby constantly for official recognition, aid, and citizenship. [The Guild](../../20-Factions/guild/summary.md) has filled the gap left by the official government, providing aid and protection that Council and Fist refuse — and has earned reliable Elturian votes in return.
+
+## Threats they face
+
+- **Nativist scapegoating.** The [Plague of Remembrance](../../20-Factions/plague-of-remembrance/summary.md) actively frames Elturians as collaborators or worse to start a civil war. The [Society of Baldurian Integrity](../../20-Factions/society-of-baldurian-integrity/summary.md) treats Elturian art and architecture as "memetic contamination."
+- **Radicalization.** The [Elturel Remembrance Society](../../20-Factions/elturel-remembrance-society/summary.md) recruits from grieving Elturians for direct action against "infernal" Baldurian merchants.
+- **Disease and supply.** Periodic riverborne sickness after floods; chronic supply-gap pressure on the Outer City.
+
+## Cultural marks
+
+- **The "Last Light" loaf** sold at New Elturel's Dawnmarket — named for the Companions of the Last Light, the heroes who fought the descent into Avernus.
+- **Memorial Row** in New Elturel — pillars of carved names; ribbons left by visitors.
+- **Sun-Blessed Chapel** — three-faith sanctuary, soup kitchen, field hospital, and political assembly space all in one.

--- a/10-Setting/polities/README.md
+++ b/10-Setting/polities/README.md
@@ -1,0 +1,13 @@
+---
+name: setting-polities
+description: Institutional frameworks — trade alliances, governing systems, guild structures.
+---
+
+# Polities
+
+Institutional frameworks at the *system* level. Specific instances live in `20-Factions/`; specific buildings live in `30-Places/`.
+
+## Index
+
+- [sword-coast-hansa.md](sword-coast-hansa.md) — the informal Baldur's-Gate-centered regional trade alliance.
+- [worshipful-company-system.md](worshipful-company-system.md) — institutional shape of a Worshipful Company (Master / Wardens / Court of Assistants / apprenticeship).

--- a/10-Setting/polities/sword-coast-hansa.md
+++ b/10-Setting/polities/sword-coast-hansa.md
@@ -1,0 +1,34 @@
+---
+name: sword-coast-hansa
+description: The informal Baldur's-Gate-centered regional trade alliance binding Sword Coast cities through standardized commerce.
+---
+
+# The Sword Coast Hansa
+
+The economic devastation of the [Absolute Crisis](../history/absolute-crisis.md) paradoxically paved the way for Baldur's Gate to achieve unprecedented commercial dominance. By leveraging its position on the Chionthar and its status as the largest port on the western coast, the rebuilt city has become the undisputed center of a new economic alliance: a de facto **Sword Coast Hansa**.
+
+## What it is — and isn't
+
+Not a formal, chartered alliance like the **Lords' Alliance**. The Hansa is an informal but powerful, Baldur's-Gate-centric trading bloc held together by:
+
+- **Standardized tariffs.** Member cities apply consistent customs schedules across the region.
+- **Shared commercial law.** Member courts recognize each other's contracts, judgments, and registered Worshipful Company seals.
+- **Mutual defense pacts** with the smaller cities along the coast: Daggerford, Beregost, and the towns of the Western Heartlands. These pacts protect trade routes more than borders.
+
+The Hansa is in this sense a project of the [Council of Four](../../20-Factions/council-of-four/summary.md), the [Foreign Kontors](../../20-Factions/amnian-kontor/summary.md), and the native [Chionthar Consortium](../../20-Factions/chionthar-consortium/summary.md) and [Western Gate Trading Company](../../20-Factions/western-gate-trading-company/summary.md) — the entities that benefit most from frictionless cross-city commerce.
+
+## Why it works
+
+- **Geography.** The Chionthar is the natural east-west spine for the western Heartlands; the Sea of Swords is the natural north-south spine for the western coast. Baldur's Gate sits at the intersection.
+- **Capital.** Amnian banking (issued through the Gold-Gable Hall) underwrites cross-city contracts and currency exchange across the bloc.
+- **Demand.** Lantaner smokepowder, Waterdhavian magical goods, and Sembian bulk logistics each create supply-chain pressures that none of the smaller polities can fulfill alone.
+
+## What it doesn't do
+
+- It does not project military force. Mutual-defense pacts exist; standing forces do not.
+- It does not bind Waterdeep. Waterdeep operates inside the Hansa via the Splendid Yard but answers to the Lords' Alliance first.
+- It does not include Amn formally. Amn participates via the Amnian Kontor; the city of Athkatla retains independent commercial policy.
+
+## Friction it creates
+
+The Hansa privileges the Kontors and large Consortiums over independent merchants. The [Free Traders of the Outskirts](../../20-Factions/free-traders-of-the-outskirts/summary.md) are the most organized resistance to standardized tariffs at the gate. The [Patriar Heritage Society](../../20-Factions/patriar-heritage-society/summary.md) sees the Hansa as the formal extension of the [Great Bargain's](../history/great-bargain.md) erosion of Baldurian sovereignty.

--- a/10-Setting/polities/worshipful-company-system.md
+++ b/10-Setting/polities/worshipful-company-system.md
@@ -1,0 +1,37 @@
+---
+name: worshipful-company-system
+description: Institutional shape of a Worshipful Company — Master, Wardens, Court of Assistants, and the apprentice ladder.
+---
+
+# The Worshipful Company System
+
+The craft guilds of Baldur's Gate, taking inspiration from the highly structured guilds of cities like Waterdeep, have consolidated into **Worshipful Companies**. Each Company is a chartered monopoly, a social institution, and a political force. To practice a trade within the city walls without being a member of the appropriate Company is illegal and invites the swift wrath of its Wardens.
+
+The list of specific Companies lives in [20-Factions/README.md](../../20-Factions/README.md). This file describes the institutional shape they share.
+
+## Hierarchy
+
+Each Company is a self-contained pyramid:
+
+- **The Master.** Elected head, serves a one-to-five-year term. Public face of the guild; sits on its boards; often holds a seat in the [Peerage of Coin](../../20-Factions/peerage-of-coin/summary.md).
+- **The Wardens.** Two or three senior members acting as the Master's executive officers. Oversee finances, manage Company properties, command the **Guild Wardens** (the Company's enforcement arm).
+- **The Court of Assistants.** A council of a dozen or more senior masters who form the Company's governing body. Set policy, approve new members, judge internal disputes.
+- **Masters, Journeymen, Apprentices.** The body of the guild. An apprentice serves a **seven-year** term under a master. On completion, they become a journeyman — skilled and hireable. To become a master, a journeyman produces a **masterpiece** for the Court of Assistants and pays a hefty fee to establish their own workshop.
+
+## Powers and reach
+
+Companies regulate every aspect of their trade:
+
+- **Set prices.** Cost of goods and services across the city.
+- **Enforce quality standards.** Through inspection and seal.
+- **Control labor supply.** Number of apprentices is capped to prevent flooding the market.
+- **Maintain enforcement.** Guild Wardens are deputized agents whose authority — granted by Company charter — is **absolute over guild members and property** anywhere in the city. This is the source of constant jurisdictional friction with the Flaming Fist, the Watch, and the Kontor guards.
+- **Provide social infrastructure.** Guildhalls double as administrative centers, social clubs, chapels to a patron deity, and charitable institutions for sick or elderly members and their families.
+
+## Why this matters politically
+
+The Companies are the third leg of the city's plutocracy stool, alongside the Foreign Kontors and the Merchant Consortiums. They hold seats in the [Peerage of Coin](../../20-Factions/peerage-of-coin/summary.md) (allocated by tax receipts; reweighted annually). Their collective voice can sway the [Council of Four](../../20-Factions/council-of-four/summary.md) when they align — which is rare, because they compete with each other for materials, apprentices, and Council favor.
+
+## The Sorcerous Sodality footnote
+
+The [Sorcerous Sodality](../../20-Factions/wc-sorcerous-sodality/summary.md) is not a traditional Company but holds an analogous charter: it regulates the sale of magical goods and licenses public spellcasting. It is treated, for political purposes, as a thirteenth Great Company.

--- a/30-Places/README.md
+++ b/30-Places/README.md
@@ -6,4 +6,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the geographic layout and depth conve
 
 ## Index
 
-_(empty — populate as places are added)_
+- [sword-coast/](sword-coast/README.md) — the western coast region; Baldur's Gate and the Hansa-aligned cities.

--- a/30-Places/sword-coast/README.md
+++ b/30-Places/sword-coast/README.md
@@ -1,0 +1,21 @@
+---
+name: sword-coast
+description: Region index — the western coast of Faerûn from Waterdeep to Calimshan, anchored on Baldur's Gate.
+---
+
+# Sword Coast
+
+The stretch of western Faerûn from Waterdeep down past Baldur's Gate toward Amn and Calimshan, plus the Sea of Swords and the inland Western Heartlands. In 1502 DR, Baldur's Gate is the region's commercial hub, the head of the informal **Sword Coast Hansa**.
+
+## Index
+
+- [polities.md](polities.md) — short index of the region's governing bodies and trade alliances; the Hansa framework lives in [10-Setting/polities/sword-coast-hansa.md](../../10-Setting/polities/sword-coast-hansa.md).
+- [demographics.md](demographics.md) — regional ancestry and movement patterns at the cross-city scale.
+- [baldurs-gate/](baldurs-gate/README.md) — the city itself; Upper / Lower / Outer / Undercity wards.
+
+## Neighbors and adjacent dossiers
+
+- North: Waterdeep (#21 forthcoming) and the Sword Coast North.
+- South: Amn (Athkatla), Calimshan, and the Sembian-influenced trade corridor.
+- West: Sea of Swords (#20 forthcoming).
+- East: Hinterlands of Baldur's Gate (#23 forthcoming) — Beregost, Nashkel, Boareskyr Bridge, the Wood of Sharp Teeth.

--- a/30-Places/sword-coast/baldurs-gate/README.md
+++ b/30-Places/sword-coast/baldurs-gate/README.md
@@ -1,0 +1,33 @@
+---
+name: baldurs-gate
+description: City index — the Phoenix on the Chionthar, ten years after the Absolute Crisis.
+---
+
+# Baldur's Gate
+
+A city of ~145,000 souls on the north bank of the Chionthar, a few days' sail from the Sea of Swords. Founded by the adventurer Balduran around 1068 DR; rebuilt at foreign expense after the Absolute Crisis of 1492 DR; today the head of the Sword Coast Hansa and a working plutocracy.
+
+## City-level files
+
+- [character.md](character.md) — vibe, civic identity, demographic texture.
+- [factions.md](factions.md) — cross-link table to the [20-Factions/](../../../20-Factions/) tree; no prose duplication.
+- [neighbors.md](neighbors.md) — adjacent regions, river/road connections, the Outer City borough geography.
+- [history.md](history.md) — BG-specific events; full setting history lives in [10-Setting/history/](../../../10-Setting/history/).
+- [governance.md](governance.md) — the Council, Parliament, and Watch *as they sit in this city*; system framing is in [10-Setting/polities/](../../../10-Setting/polities/).
+
+## Wards
+
+The city has three walled tiers and a buried fourth:
+
+- [upper-city/](upper-city/README.md) — Manorborn, the Temples District, the Wide; Watch-policed, Old-Wall-gated.
+- [lower-city/](lower-city/README.md) — the commercial heart from the Old Wall down to Gray Harbour; seven named neighborhoods plus the Kontor enclaves.
+- [outer-city/](outer-city/README.md) — unwalled boroughs across the river and along the trade roads; New Elturel, Rivington, Wyrm's Crossing, the K'liir, more.
+- [undercity/](undercity/README.md) — the sewer labyrinth and the Undercellar smugglers' market beneath the Wide.
+
+## Key gates
+
+- **Baldur's Gate (Old Wall)** — namesake arch dividing Upper from Lower City; 5 cp passage fee, Watch-controlled.
+- **Basilisk Gate** — main eastern outer-wall gate, opens onto the Coast Way; Flaming Fist customs.
+- **Cliffgate** — fog-shrouded western gate; serves Tumbledown and the graveyards.
+- **Black Dragon Gate** — south outer gate onto the Trade Way; opens onto Blackgate's caravan circles.
+- **Wyrm's Crossing** — the great bridge over the Chionthar; not a gate but the city's true southern artery.

--- a/30-Places/sword-coast/baldurs-gate/character.md
+++ b/30-Places/sword-coast/baldurs-gate/character.md
@@ -1,0 +1,34 @@
+---
+name: baldurs-gate-character
+description: The Phoenix on the Chionthar — civic identity, mood, and demographic texture in 1502 DR.
+---
+
+# Character
+
+Baldur's Gate is a scar that learned to monetize itself. A decade after the Absolute Crisis, the city is louder, richer, and more vibrant than ever — and its soul answers to the clink of foreign coin and the cold logic of the ledger. Pale new stone rises beside soot-stained pre-crisis facades; cranes are as common as gulls over Gray Harbour.
+
+## Civic identity
+
+A survivor's paradox. Almost arrogant pride in the city's resilience, coupled with deep, gnawing paranoia. After the Bhaalspawn Saga, the Fall of Elturel, and the Absolute Crisis, the populace and the leadership are willing to entertain any bargain, any alliance, and any sacrifice of old traditions for security and prosperity. The chaos of the Netherbrain's fall created a power vacuum that capital filled. The new Baldur's Gate has, in a real sense, been sold to the highest bidders to ensure it would not fall again.
+
+This animates two campaign-frame principles distilled in [00-Campaign-Frame/economics.md](../../../00-Campaign-Frame/economics.md) and [00-Campaign-Frame/power.md](../../../00-Campaign-Frame/power.md).
+
+## Demographic texture
+
+About 145,000 souls live in the city and its immediate environs (up from ~125,000 pre-crisis).
+
+- **Humans (~70%).** Stratified between native **Baldurians**, **Elturians** (refugees, concentrated in New Elturel), and **Foreign Nationals** (Amnian, Waterdhavian, Sembian) inside the Kontor enclaves.
+- **Tieflings (~8%).** Swelled by the Elturian diaspora; a strong, self-reliant New Elturel community; courted by The Guild, eyed with suspicion by nativists.
+- **Dwarves (~6%).** Cornerstone of the craft industries — Masons, Smiths, Goldsmiths.
+- **Elves and half-elves (~5%).** Stable across all classes; well represented in the Waterdhavian Kontor and the Sorcerous Sodality.
+- **Halflings and gnomes (~4%).** Publicans, smugglers, tinkers, alchemists; gnomes cluster around the Lantaner Concession and Whitkeep.
+- **Githyanki (~1%).** The K'liir; aloof, formidable, in self-imposed exile.
+- **Others (~6%).** Dragonborn, half-orcs, reformed goblinoids, lizardfolk; the port absorbs everyone the road sends.
+
+## Geography in one paragraph
+
+The city sits on a great bluff on the north bank of the Chionthar. Verticality and walls define it: the Upper City rules the bluff, the Lower City spills down to the harbor, and the Outer City sprawls beyond the walls — most heavily across the river via Wyrm's Crossing. The Undercity runs beneath all of it.
+
+## Source
+
+`raw-ingest/cloaks-and-conspiracies/dossier-baldurs-gate-1502-dr-a-city-reborn.docx` Chapters 1, 10, 13.

--- a/30-Places/sword-coast/baldurs-gate/factions.md
+++ b/30-Places/sword-coast/baldurs-gate/factions.md
@@ -1,0 +1,58 @@
+---
+name: baldurs-gate-factions
+description: Cross-link table to faction folders active in Baldur's Gate. Prose lives in 20-Factions/.
+---
+
+# Factions in Baldur's Gate
+
+Cross-link table only — never duplicate prose from `20-Factions/`. Every entry below is a pointer to that faction's `summary.md`.
+
+## Government
+
+- [Council of Four](../../../20-Factions/council-of-four/summary.md) — the executive boardroom.
+- [Parliament of Peers](../../../20-Factions/parliament-of-peers/summary.md) — bicameral legislature: Blood + Coin.
+- [Peerage of Blood](../../../20-Factions/peerage-of-blood/summary.md) — 50 hereditary patriar seats.
+- [Peerage of Coin](../../../20-Factions/peerage-of-coin/summary.md) — 50 economic-bloc seats reweighted annually.
+- [Patriar Heritage Society](../../../20-Factions/patriar-heritage-society/summary.md) — voting bloc of old-money families.
+
+## Security
+
+- [Flaming Fist](../../../20-Factions/flaming-fist/summary.md) — diminished mercenary company; Upper City + walls + customs.
+- [The Watch](../../../20-Factions/watch/summary.md) — patriar-funded Upper City detail.
+- Kontor guards (Coin-Swords / Griffin Guard / Iron Guard / Lantaner sentinels) — see each Kontor folder.
+
+## Foreign Kontors and consortiums
+
+- [Amnian Kontor](../../../20-Factions/amnian-kontor/summary.md), [Waterdhavian Kontor](../../../20-Factions/waterdhavian-kontor/summary.md), [Sembian Kontor](../../../20-Factions/sembian-kontor/summary.md), [Lantaner Concession](../../../20-Factions/lantaner-concession/summary.md).
+- [Chionthar Consortium](../../../20-Factions/chionthar-consortium/summary.md), [Western Gate Trading Company](../../../20-Factions/western-gate-trading-company/summary.md).
+- Remnant costers: [High Moon](../../../20-Factions/high-moon-coster/summary.md), [Iron Throne](../../../20-Factions/iron-throne/summary.md), [Seven Suns](../../../20-Factions/seven-suns/summary.md).
+
+## Worshipful Companies
+
+Twelve Great Companies plus lesser ones; index lives in [20-Factions/README.md](../../../20-Factions/README.md). Framework: [10-Setting/polities/worshipful-company-system.md](../../../10-Setting/polities/worshipful-company-system.md).
+
+## Underworld and street
+
+- [The Guild](../../../20-Factions/guild/summary.md) — de facto government of the Lower / Outer City.
+- [Zhentarim](../../../20-Factions/zhentarim/summary.md), [River-Rats](../../../20-Factions/river-rats/summary.md), [Wharf Rats](../../../20-Factions/wharf-rats/summary.md).
+- [The Bibliophile](../../../20-Factions/bibliophile/summary.md) — Bloomridge information broker.
+- [Free Traders of the Outskirts](../../../20-Factions/free-traders-of-the-outskirts/summary.md), [Hellriders of New Elturel](../../../20-Factions/hellriders-of-new-elturel/summary.md), [The Unchained](../../../20-Factions/unchained/summary.md).
+
+## Press, conspiracy, cult
+
+- [Baldur's Mouth](../../../20-Factions/baldurs-mouth/summary.md).
+- [Harpers](../../../20-Factions/harpers/summary.md), [Knights of the Shield](../../../20-Factions/knights-of-the-shield/summary.md), [Circle of the Inner Grove](../../../20-Factions/circle-of-the-inner-grove/summary.md).
+- Cults: [Cult of the Returning Lord](../../../20-Factions/cult-of-the-returning-lord/summary.md), [Silent Shroud](../../../20-Factions/silent-shroud/summary.md), [Hands of the Absolute](../../../20-Factions/hands-of-the-absolute/summary.md), [Followers of the Phoenix](../../../20-Factions/followers-of-the-phoenix/summary.md), [The Gilded Vein](../../../20-Factions/gilded-vein/summary.md), [The Gravekeepers](../../../20-Factions/gravekeepers/summary.md), [Carnival of Whispers](../../../20-Factions/carnival-of-whispers/summary.md), [Plague of Remembrance](../../../20-Factions/plague-of-remembrance/summary.md), [Takers of the Tithe](../../../20-Factions/takers-of-the-tithe/summary.md).
+- Conspiracy cells: [Elturel Remembrance Society](../../../20-Factions/elturel-remembrance-society/summary.md), [The Purified](../../../20-Factions/purified/summary.md), [Society of Baldurian Integrity](../../../20-Factions/society-of-baldurian-integrity/summary.md), [The Unveiled](../../../20-Factions/unveiled/summary.md).
+
+## Notable structures and where to find them
+
+- **Wyrm's Rock Fortress** — Flaming Fist HQ on Wyrm's Crossing; see [outer-city/](outer-city/README.md).
+- **High Hall** — Council and Parliament chamber; Upper City Temples District; see [governance.md](governance.md).
+- **Sorcerous Sundries** — Sorcerous Sodality HQ in Heapside, Lower City.
+
+## Roster verification (issue #19)
+
+Cross-checked Part V "Directory of Influence" of `dossier-baldurs-gate-1502-dr-a-city-reborn.docx` against `20-Factions/`. **Every Part V faction has a folder.** No gaps.
+
+Sub-factions in Part V (the Watch as a Flaming-Fist division; the K'liir as the Unchained's encampment; the four Foreign Kontors enumerated as a single entry) are correctly broken out into their own folders. Cult and conspiracy folders that exist beyond Part V (`carnival-of-whispers`, `gilded-vein`, `plague-of-remembrance`, `purified`, `society-of-baldurian-integrity`, `takers-of-the-tithe`, `unveiled`, `elturel-remembrance-society`) are sourced from `factions.docx` and `faction-quests.xlsx`, not Part V.

--- a/30-Places/sword-coast/baldurs-gate/governance.md
+++ b/30-Places/sword-coast/baldurs-gate/governance.md
@@ -1,0 +1,39 @@
+---
+name: baldurs-gate-governance
+description: How the Council, Parliament, and security forces sit in this city. Framework lives in 10-Setting.
+---
+
+# Governance
+
+This file describes governance **as it sits in Baldur's Gate** — the buildings, the jurisdictions, the cracks between them. The institutional framework (how a Worshipful Company is structured, what the Hansa is) lives in [10-Setting/polities/](../../../10-Setting/polities/).
+
+## The High Hall
+
+Both chambers and the Council meet in the **High Hall**, atop the Upper City's bluff in the Temples District. Public hearings are held here; petitions arrive at dawn and are processed with ritual exactness. Council ratification of legislation happens in a smaller chamber off the main floor. See [upper-city/](upper-city/README.md).
+
+## Council of Four
+
+Four Dukes; one of them sits as **Archduke** based on the previous fiscal year's tax contribution from their affiliated bloc. Currently **Lyra Silvershield** of the Western Gate Trading Company (Bloomridge Park Manor, Upper City). Faction prose: [council-of-four](../../../20-Factions/council-of-four/summary.md).
+
+## Parliament of Peers
+
+100 seats split bicamerally:
+
+- **Peerage of Blood** — 50 hereditary patriar seats. Citizens of every type now carry a vote for who fills these seats — a 1497 concession that has tied the patriars' political fate to the Lower City for the first time. The Guild leverages this hard.
+- **Peerage of Coin** — 50 seats allocated to the largest economic blocs annually by tax receipts. Kontors, consortiums, Worshipful Companies trade seats yearly. A cauldron of naked ambition where laws are bought and sold.
+
+Bills must pass both chambers before Council ratification.
+
+## Security: a patchwork
+
+Justice in Baldur's Gate is a commodity. Quality scales with wealth, guild membership, and district.
+
+- **The Flaming Fist** — Upper City policing, walls, customs at the gates and Gray Harbour. HQ at Wyrm's Rock Fortress on Wyrm's Crossing. Underfunded and resented.
+- **The Watch** — patriar-funded Upper City detail; better-equipped than the Fist within its narrow remit.
+- **Guild Wardens** — chartered guild enforcers with absolute jurisdiction over their members city-wide. See [10-Setting/polities/worshipful-company-system.md](../../../10-Setting/polities/worshipful-company-system.md).
+- **Kontor guards** — sovereign within their Kontor walls (Amnian Coin-Swords, Waterdhavian Griffin Guard, Sembian Iron Guard, Lantaner sentinels). Extraterritoriality is law inside the gates and a constant friction outside them.
+- **Ward Boss system** — for the Lower and Outer Cities, the law is The Guild's. Ward Bosses run "social clubs" that double as community centers and informal courts; see [guild summary.md](../../../20-Factions/guild/summary.md).
+
+## Practical implications
+
+A street brawl can cross four jurisdictions in a hundred feet: Watch, Fist, Kontor guards, Guild Wardens. Which one shows up first determines how the case is filed — or whether it's filed at all.

--- a/30-Places/sword-coast/baldurs-gate/history.md
+++ b/30-Places/sword-coast/baldurs-gate/history.md
@@ -1,0 +1,42 @@
+---
+name: baldurs-gate-history
+description: Compact city-specific history; full setting timeline lives in 40-Timeline and 10-Setting/history.
+---
+
+# History
+
+City-specific notes only. Region-wide events live in [10-Setting/history/](../../../10-Setting/history/); the dated chronology lives in [40-Timeline/history.md](../../../40-Timeline/history.md).
+
+## Founding
+
+c. **1068 DR** — the adventurer **Balduran** returns from Anchorome, walls the fishing village of Gray Harbour (formerly Loklee), and renames it after himself. The city's foundation is rooted in adventure and commerce — a pattern it has never broken.
+
+## The Bhaalspawn era (1368–1370 DR)
+
+The Iron Crisis and the Bhaalspawn Crisis stamped Baldur's Gate as a place where divine schemes routinely break against mortal pragmatism. Sarevok Anchev tried to spark a war with Amn for godhood; Abdel Adrian stopped him and later forsook the Throne of Bhaal. Both events are first-rank Baldurian civic legend.
+
+## The Flaming Fist (1370 DR)
+
+Founded by Grand Duke Eltan as a mercenary company, almost immediately hired as the city's police and military. Their long arc from chartered army to politically neutered customs detail defines a century of city security politics.
+
+## The Emperor's manipulation (1477–1482 DR)
+
+Balduran himself, now a mind flayer styling himself the Emperor, returns and dominates Duke Stelmane to manipulate city politics from the shadows. This sets the table for the Murder in Baldur's Gate (1482) — Grand Duke Abdel Adrian killed by his last Bhaalspawn sibling Viekang, allowing the resurrection of Bhaal.
+
+## The Absolute Crisis (1492 DR)
+
+The Cult of the Absolute, secretly run by Chosen of the Dead Three and a Netherbrain, nearly took the city. Heroes destroyed the brain; the Heapside and Eastway districts bore the worst physical damage. Grand Duke Ulder Ravengard was rescued but politically compromised; Ducal seats were vacant or tainted. The city emerged saved but bankrupt and fractured.
+
+## The Decade of Reconstruction (1492–1502 DR)
+
+See [10-Setting/history/decade-of-reconstruction.md](../../../10-Setting/history/decade-of-reconstruction.md) for the framework. City-specific consequences:
+
+- The **Heapside / Eastway** rebuild is the architectural signature of the new city — pale clean stone next to soot-stained pre-crisis facades.
+- The **Outer City** swelled into an Elturian-led shantytown that became a permanent borough.
+- **Wyrm's Rock Fortress** survived as the Fist's HQ but became a monument to lost relevance.
+
+## Where to read the rest
+
+- [40-Timeline/history.md](../../../40-Timeline/history.md) — every dated event in chronological order.
+- [10-Setting/history/great-bargain.md](../../../10-Setting/history/great-bargain.md) — the post-crisis charter.
+- [10-Setting/history/1497-reformation.md](../../../10-Setting/history/1497-reformation.md) — Parliament restructure.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/README.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/README.md
@@ -1,0 +1,23 @@
+---
+name: lower-city
+description: Crescent of commerce between the Old Wall and Gray Harbour; the city's beating heart.
+---
+
+# Lower City
+
+The chaotic, energetic, dangerous crescent of humanity pressed between the bluff of the Upper City and the waters of the Gray Harbour. The city's real work happens here. A maze of slate-roofed tenements, workshops, raucous taverns, and bustling marketplaces, all packed together and crisscrossed by bridges and buttresses to keep them from sliding into the harbor.
+
+## Index
+
+- [character.md](character.md) — vibe, the patchwork of jurisdictions, the rhythm of work and water.
+- [brampton.md](brampton.md) — far eastern crook; smuggling-friendly.
+- [eastway.md](eastway.md) — caravan inflow from the Basilisk Gate.
+- [heapside.md](heapside.md) — northeast workshops, **Sorcerous Sundries**, the Baldur's Mouth printshop.
+- [the-steeps.md](the-steeps.md) — switchback shopping high street climbing toward the Old Wall.
+- [bloomridge.md](bloomridge.md) — fashionable merchant townhouses with harbour views; **the Bibliophile**.
+- [seatower.md](seatower.md) — western military spit; Seatower of Balduran, **Forge of the Nine**.
+- [gray-harbour.md](gray-harbour.md) — the working waterfront; the four Foreign **Kontor** enclaves.
+
+## Jurisdictions, in this ward
+
+Four authorities overlap. The **Flaming Fist** holds the gates and customs. The **Worshipful Company Wardens** hold their members anywhere. The **Kontor guards** hold their own walled enclaves. Everywhere else — and everywhere in between — the law is the **Guild's** Ward Bosses. See [governance.md](../governance.md).

--- a/30-Places/sword-coast/baldurs-gate/lower-city/bloomridge.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/bloomridge.md
@@ -1,0 +1,27 @@
+---
+name: bloomridge
+description: Fashionable merchant townhouses with harbour views; salons, perfumers, the Bibliophile.
+---
+
+# Bloomridge
+
+Perched for views over Gray Harbour, Bloomridge is fashionable without trying too hard — color-washed townhouses with rooftop gardens, tidy balconies, and salons where trends are invented over citrus wine. The money here is merchant-born and proud of it.
+
+## Notable stops
+
+- **Facemaker's Boutique.** Figaro "Facemaker" Pennygood cuts cloth and social anxieties in equal measure; fittings are appointments and performances both.
+- **The Bibliophile.** Nansi Gretta's bookshop smells of leather and peppermints. The back table is where information changes hands, politely. HQ of the [Bibliophile](../../../../20-Factions/bibliophile/summary.md) intelligence ring.
+- **Bonecloak's Apothecary & Crimson Draughts.** Twin emporia for remedies, reagents, and respectable vices; everything labeled, nothing entirely innocent. **Crimson Draughts** is a sanctioned [Worshipful Company of Alchemists & Apothecaries](../../../../20-Factions/wc-alchemists-apothecaries/summary.md) outlet.
+- **Outlook Promenade.** A pocket park along the ridge with benches for harbor-watching and gossiping without witnesses.
+
+## Who lives here
+
+Prosperous factors, Kontor agents, retired ship captains, and artisans who made it big. Many homes have staff quarters tucked under the eaves.
+
+## Etiquette and access
+
+Dress presentably (clean boots count), book before you browse in the top shops, and let the shopkeeper steer the conversation — especially if you want the *real* catalogue.
+
+## Pressures
+
+Petty status wars; rising rents pushing tradespeople downhill; "Dandies" (well-bred bravo crews) who sometimes mistake neighborhood pride for license. The Guild prefers velvet gloves here, but the iron is real. The [Knights of the Shield](../../../../20-Factions/knights-of-the-shield/summary.md) probe Bloomridge salons for rising-merchant marks.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/brampton.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/brampton.md
@@ -1,0 +1,27 @@
+---
+name: brampton
+description: Far eastern crook of the Lower City; cramped lanes, false-floored "warehouses," and questions that aren't asked.
+---
+
+# Brampton
+
+Tucked into the Lower City's far eastern crook, Brampton is where the map frays and the rules do, too. Legitimate trade rarely bothers with its cramped lanes; that suits Brampton's residents fine. The neighborhood's reputation — grimy, insular, convenient for anything you don't want inspected at the Basilisk Gate — keeps rents low and questions lower.
+
+## Notable stops
+
+- **Hidden Warehouses.** "Abandoned" by daylight; false floors, swing-walls, and soot-black hoists by lanternlight. The smartest crews never use the same cache twice.
+- **The Salt-Cellar.** A low-beamed tavern that changes proprietors and passwords every season. Honest chowder; dishonest back room.
+- **The Sootwell Steps.** A slant of wet stone dropping beneath a cooper's yard to an old service tunnel. Locals swear the Steps "never quite end."
+- **Tally Court.** Open square where gray-market factors meet between ledgers. Chalk marks on posts indicate which crews hold the peace that day.
+
+## Who lives here
+
+Cartmen, coopers, sweepers, a few luckless apprentices, and far more "clerks" than any honest census would admit. Strong [Guild](../../../../20-Factions/guild/summary.md) presence; [Zhentarim](../../../../20-Factions/zhentarim/summary.md) cells probe at the edges.
+
+## Etiquette and access
+
+Walk with a purpose. Don't gawk at shuttered doors or count crates aloud. If someone asks who you're seeing, have a name ready — even if it's a bluff.
+
+## Pressures
+
+Smuggling routes contested by Guild crews and would-be independents; Flaming Fist sweeps that seize little but break plenty; occasional fires that "start themselves" on properties whose owners snub the local Ward Boss. The [River-Rats](../../../../20-Factions/river-rats/summary.md) work the sewer outflows beneath Brampton.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/character.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/character.md
@@ -1,0 +1,31 @@
+---
+name: lower-city-character
+description: The cauldron of commerce — chaotic, opportunity-thick, jurisdictionally fractured.
+---
+
+# Character
+
+The Lower City is the true heart of Baldur's Gate — a chaotic, energetic, and dangerous crescent. Crime is rampant, but so is opportunity. Every block is a different deal in a different language with a different guild seal on the contract.
+
+## What you notice
+
+Slate roofs in tight rows; bridges and buttresses propping up tenements that lean on each other. Tar, salt, and fish from the harbor; smoke from forges and kitchens; ink and parchment from countinghouses. Lamplighters mark the bells at dusk. The Old Wall looms uphill; the Gray Harbour glints below.
+
+## Mood
+
+Pragmatic and loud. People remember faces and forget names on purpose. A handshake here is binding because the alternative — a Worshipful Company Warden dragging the case to a Court of Assistants — is worse for everyone. The Guild's quiet weight keeps the streets functional.
+
+## How law lands
+
+A street brawl can cross four jurisdictions in a hundred feet:
+
+- **Flaming Fist** — gates, walls, customs, and (badly) the Lower City patrols.
+- **Worshipful Company Wardens** — chartered to police their own membership, anywhere in the city.
+- **Kontor guards** — sovereign within their walled enclaves; extraterritorial.
+- **Guild Ward Bosses** — actual day-to-day arbitration in the tenements and back lanes.
+
+Which one shows up first determines how the case is filed — or whether it is filed at all.
+
+## Who lives here
+
+Crafters, carters, dockworkers, scribes, journeymen, sailors, smiths, lamplighters, factors, sailmakers, three generations sharing a stair. Foreign nationals inside the Kontor walls. Patriar staff commuting downhill at dawn and back uphill at dusk.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/eastway.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/eastway.md
@@ -1,0 +1,31 @@
+---
+name: eastway
+description: Caravan-inflow district fanning from the Basilisk Gate; inns, stables, porters, and a churning crowd.
+---
+
+# Eastway
+
+Eastway fans out from the Basilisk Gate like a wake from a prow. It is the Lower City's hello and goodbye: a hard-working belt of inns, stables, and porters catering to caravans rolling in from the Coast Way. The crowd changes by the hour; the racket does not.
+
+## Notable stops
+
+- **Basilisk Gate Barracks & Heapside Prison.** Tolls, papers, inspections — then cells for those whose luck or tempers fail. The barracks courtyard posts road notices and bounty bills at dawn.
+- **The Singing Lute.** A bright, busy inn where caravan masters hire guards and bards trade routes for verses. Famous stew; discreet back room.
+- **Tallgate Stables.** Honest hay, decent farriers, a wry owner who has seen every scam twice.
+- **Porters' Stone.** A scarred granite block serving as the informal hiring hall. Foremen chalk the day's rates.
+
+## Who lives here
+
+Innkeepers, wheelwrights, quick-fingered guides, shrine-tenders, and pickpockets. Many families rent rooms above their shops and sleep in shifts during festival weeks.
+
+## Etiquette and access
+
+Keep your purse in front and your papers handy. Haggle, but don't waste time — someone behind you will pay the posted rate. Peace-tie weapons when the Watch asks; it speeds everything.
+
+## Pressures
+
+Confidence games targeting first-timers, caravan theft rings testing stables after midnight, tension every time tolls rise faster than wages. The [Free Traders of the Outskirts](../../../../20-Factions/free-traders-of-the-outskirts/summary.md) bring grievances about gate tariffs here first.
+
+## Note on damage
+
+Eastway took heavy damage during the Absolute Crisis and is one of the two districts whose Decade-of-Reconstruction rebuild defines the city's pale-stone-on-soot look (the other being Heapside).

--- a/30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md
@@ -1,0 +1,38 @@
+---
+name: gray-harbour
+description: The working waterfront and Dock Ward; piers, the four Foreign Kontor enclaves, the Steel Watch Foundry.
+---
+
+# Gray Harbour (the Dock Ward)
+
+The Lower City's working waterfront — piers bristling with masts, winches clacking, foremen shouting schedules over gulls and surf. If coin has a tide, it rises and falls here. Ships from Amn to Icewind Dale unload at dawn, deals are struck by noon, and by dusk the taverns are louder than the cranes.
+
+## Notable stops
+
+- **The Blushing Mermaid.** Notorious, barnacled tavern partly housed in the ribs of an old hulk. Fights are common; information is cheaper than the beer and twice as strong.
+- **The Counting House.** The port's private bank and clearinghouse. Factors queue with ledgers; bodyguards wait with blank expressions.
+- **Water Queen's House (Umberlee).** Sailors pay the Bitch Queen in coin or trinkets before casting off. The stairs are always wet.
+- **Steel Watch Foundry.** A shuttered, iron-boned factory from Gortash's heyday. The Fist keeps a cordon around it; scavengers keep finding new ways in and worse reasons to regret it.
+
+## The Foreign Kontors
+
+Four walled compounds line the waterfront, each operating under home-nation law:
+
+- **The Gold-Gable Hall** — [Amnian Kontor](../../../../20-Factions/amnian-kontor/summary.md). Banking, southern luxuries, currency exchange. Coin-Swords on the walls.
+- **The Splendid Yard** — [Waterdhavian Kontor](../../../../20-Factions/waterdhavian-kontor/summary.md). Magical goods, finished textiles, and (unofficially) Lords' Alliance and Harper intelligence. Griffin Guard.
+- **The Iron Ledger** — [Sembian Kontor](../../../../20-Factions/sembian-kontor/summary.md). Bulk goods, mercenary contracts, logistics. Iron Guard.
+- **The Cogwork Quay** — [Lantaner Concession](../../../../20-Factions/lantaner-concession/summary.md). Smokepowder, mechanical devices, invention. Gnomish sentinels and stranger countermeasures.
+
+Outside their walls cluster hawkers who know exactly what each nation misses from home.
+
+## Who lives here
+
+Dockworkers, net-menders, sailmakers, chandlers, a dozen breeds of clerk. Foreign nationals inside the Kontor walls. Families measure years in successful returns to port.
+
+## Etiquette and access
+
+Don't stand on a gangplank, don't argue with a crane signalman, don't short a union crew on their fee. If a sailor says "one for Umberlee," follow suit and toss a coin.
+
+## Pressures
+
+Smuggling threaded through legitimate manifests; Kontor politics that spill into alley brawls; warehouse fires that start "by themselves"; periodic strikes when wages lag the risk. The [Wharf Rats](../../../../20-Factions/wharf-rats/summary.md) under One-Eyed Jack run the dockworkers' union as a Guild satellite.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/heapside.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/heapside.md
@@ -1,0 +1,31 @@
+---
+name: heapside
+description: Northeast Lower City workshops; Sorcerous Sundries and the Baldur's Mouth printshop.
+---
+
+# Heapside
+
+Heapside runs along the Lower City's northeast — a neighborhood of honest noise and honest work. Workshops spill sparks, hawkers call from stoops, and the lanes smell of fresh bread, hot iron, and ink. If the Lower City has a conscience, it lives here, alongside a very practical sense of survival.
+
+## Notable stops
+
+- **Sorcerous Sundries (the Sorcerous Sodality).** The many-domed landmark where licensed magic is bought, warded, and argued over. Apprentices everywhere; a posted schedule of "acceptable pyrotechnics." HQ of the [Sorcerous Sodality](../../../../20-Factions/wc-sorcerous-sodality/summary.md).
+- **Baldur's Mouth Printshop.** Five narrow stories of gears, galleys, and gossip. Broadsheets fly at first light; rumors take wing earlier. HQ of the [Baldur's Mouth](../../../../20-Factions/baldurs-mouth/summary.md), edited by Ettvard Needle.
+- **Shrine of the Suffering (Ilmater).** A plain doorstep ministry with bandages, soup, and patience. Volunteers know every family by name.
+- **The Winch & Whistle.** Corner tavern favored by smiths and scribes alike; tools lean by the hearth.
+
+## Who lives here
+
+Crafters, carters, scribes, lamplighters, and three generations sharing the same narrow stair. Heapsiders argue politics at breakfast and prices at lunch — and still help you move a chest at dusk.
+
+## Etiquette and access
+
+Pay the going rate, return borrowed tools, don't block a lane with idle talk. If a neighbor asks you to "mind the pot," do it.
+
+## Pressures
+
+Rents creeping up; guild consolidation squeezing independents; the occasional sealed cellar best left that way after the Absolute Crisis. The Guild keeps a light but real touch; when turf lines blur, fists follow.
+
+## Note on damage
+
+Heapside, with Eastway, bore the brunt of the Absolute Crisis's final battle. The pale new stone next to soot-stained pre-crisis facades is most visible here.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/seatower.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/seatower.md
@@ -1,0 +1,27 @@
+---
+name: seatower
+description: Western military spit on the river mouth; Seatower of Balduran, Forge of the Nine, drill-yard tempo.
+---
+
+# Seatower
+
+Seatower wraps the Lower City's western spit of land facing the river mouth. It beats to military time: reveille horns, ship bells, and the clatter of drill squares. On paydays the streets fill with sailors and Fist mercenaries; on storm days, with ropes, tar, and oaths strong enough to season timber.
+
+## Notable stops
+
+- **Seatower of Balduran.** The fortress on its rock, connected by a stout causeway. Access restricted; the view from the public quay is not. A secondary [Flaming Fist](../../../../20-Factions/flaming-fist/summary.md) installation.
+- **Forge of the Nine.** Dammon's workshop turns out quality steel for those who can afford it — and repairs that keep crews alive when they cannot. Independent-minded member of the [Worshipful Company of Smiths & Armorers](../../../../20-Factions/wc-smiths-armorers/summary.md).
+- **Stormshore Armoury.** Rival shop with parade-polish finishes and contracts to match; if it isn't on the rack, it can be by next watch.
+- **The Chain Locker.** Tar-and-ale tavern where shore leave starts, ends, and sometimes ends up in the brig. The stew is better than the fights.
+
+## Who lives here
+
+Flaming Fist regulars, shipwrights, dock-toughs, sailmakers, and families who measure days by tides. A handful of ministries tend to the wounded and the unlucky.
+
+## Etiquette and access
+
+Don't block a gangplank or a drill route. Present papers if asked, peace-tie blades near the causeway, and keep clear of powder stores without an escort.
+
+## Pressures
+
+Shore-leave brawls, munitions smuggling (especially Lantaner smokepowder), salvage-rights disputes after storms, and the occasional payroll-heist rumor that makes every sergeant count the chest twice. When the fleet's in, tempers and purses both run light.

--- a/30-Places/sword-coast/baldurs-gate/lower-city/the-steeps.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/the-steeps.md
@@ -1,0 +1,27 @@
+---
+name: the-steeps
+description: Switchback "high street" climbing from the wharves to the Old Wall; landings, terraces, countinghouses.
+---
+
+# The Steeps
+
+The Steeps climb from the wharves toward the Old Wall in a switchback of stone stairs, terraces, and shopfronts that seem to cling to the hillside by stubbornness alone. This is the Lower City's "high street" — porters groan uphill with crates at dawn; well-dressed buyers drift down after luncheon to spend without breaking a sweat.
+
+## Notable stops
+
+- **Old Baldur's Gate.** The namesake arch in the Old Wall caps the climb. By day a crush of permits and porters (5 cp passage fee); by night the doors close and the Watch's lanterns flare. See [upper-city/](../upper-city/README.md).
+- **Felogyr's Fireworks.** Celebratory rockets out front; serious alchemy in back. Half festival, half arsenal — ask carefully.
+- **Guild Offices and Factors' Lofts.** Discreet doorplates, locked ledgers, the occasional auction behind drawn curtains.
+- **The Stair Market.** A string of steep-step stalls: paper goods, ribbon, traveling inks, and surprisingly good pies passed hand to hand.
+
+## Who lives here
+
+Successful shopkeepers, journeymen on the rise, and a few Upper City families who like their luxuries close to the boats. Servants commute; porters never stop.
+
+## Etiquette and access
+
+Keep right on stairs, tip your porter, and don't argue with a lamplighter's schedule. If a runner calls "heads," flatten to a wall — the crate is coming through.
+
+## Pressures
+
+Class friction: Bloomridge fashions price out longtime tenants. Protection "fees" dressed up as night-watch contracts. Pickpockets prefer respectable marks over rough ones. Fire here runs uphill fast.

--- a/30-Places/sword-coast/baldurs-gate/neighbors.md
+++ b/30-Places/sword-coast/baldurs-gate/neighbors.md
@@ -1,0 +1,32 @@
+---
+name: baldurs-gate-neighbors
+description: How the city connects to the wider Sword Coast — roads, river, gates, and the Outer City reach.
+---
+
+# Neighbors
+
+## Approaches
+
+- **Coast Way (south and east).** Caravans roll up to the **Basilisk Gate** through Eastway. North of the city the road follows the coast toward Beregost, Nashkel, Amn.
+- **Trade Way (south).** Comes up from the south interior to the **Black Dragon Gate** in Blackgate; merges with the Coast Way.
+- **Chionthar River (east-west).** The lifeline. River trade flows from the inland Western Heartlands down to the Sea of Swords, with **Gray Harbour** the deepwater terminus.
+- **Sea of Swords (west).** Deepwater traffic from Waterdeep, Luskan, and beyond unloads in Gray Harbour; the dossier #20 covers the sea-side.
+
+## Outer City reach
+
+The Outer City is not a single thing. From the city's perspective:
+
+- **South across Wyrm's Crossing:** Rivington, Wyrm's Crossing proper, New Elturel, Twin Songs, Sow's Foot, Whitkeep, Norchapel, Little Calimshan, Stonyeyes, Blackgate, the K'liir.
+- **West along the bluffs:** Tumbledown (cemeteries, stonemasons) and the Floodway below.
+- **North along the Chionthar's north bank:** caravan circles and unwalled trade-yards; predominantly Free-Traders-of-the-Outskirts territory.
+
+## Adjacent dossiers and links
+
+- **The Hinterlands** — see `raw-ingest/cloaks-and-conspiracies/the-hinterlands-of-baldurs-gate-a-dossier.docx` (issue #23).
+- **Sea of Swords** — issue #20.
+- **Waterdeep** — issue #21.
+- **Fey Courts** — `raw-ingest/cloaks-and-conspiracies/the-fey-courts-and-the-green-masquerade-1502-dr.docx`.
+
+## Friction at the seams
+
+The Outer City is taxable from the Council's perspective only at the gates and the bridge tolls. Border friction spikes whenever the **Flaming Fist** raises tolls or runs a "security visit" through Rivington or New Elturel.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/README.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/README.md
@@ -1,0 +1,35 @@
+---
+name: outer-city
+description: Unwalled boroughs and shantytowns beyond the city walls; refugee politics, caravan trade, alien enclaves.
+---
+
+# Outer City
+
+The Outer City is not a single district but a vast, chaotic sprawl of settlements that have grown beyond the taxable jurisdiction of the main walls. Refugees, transients, exiles, and those too poor or too independent to live within the Gate. Law is scarce; life is cheap; community is everything.
+
+The most significant portion lies south of the Chionthar, connected to the city by **Wyrm's Crossing**.
+
+## Index
+
+- [character.md](character.md) — vibe and the cluster of communities at a glance.
+- [new-elturel.md](new-elturel.md) — refugee borough; Hellrider militia.
+- [rivington.md](rivington.md) — south-bank gateway; caravan yards and Open Hand Temple.
+- [wyrms-crossing.md](wyrms-crossing.md) — bridge-and-fortress neighborhood; **Wyrm's Rock**.
+- [the-kliir.md](the-kliir.md) — githyanki exile encampment.
+- [tumbledown-and-floodway.md](tumbledown-and-floodway.md) — cemeteries, stonemasons, and the flood-prone tenements below.
+- [little-calimshan.md](little-calimshan.md) — walled south-Faerûn enclave; jewelers, spice, and tradition.
+
+## Other Outer City boroughs
+
+Documented inline in [character.md](character.md):
+
+- **Twin Songs** — borough of shrines and small halls; many faiths in narrow cohabitation.
+- **Sow's Foot** — multicultural market borough; Pavilion of Plenty, Menagerie of Many.
+- **Whitkeep** — gnome inventors stitched to leather and dye; tanneries plus tinker workshops.
+- **Norchapel** — quiet, devout belt around Little Calimshan; the Quiet Jacks' Hall keeps order.
+- **Stonyeyes** — livestock yards; auctions, drovers, half-orc porters.
+- **Blackgate** — Trade Way doorstep; caravan circles and the Black Dragon Gate.
+
+## Polities-in-miniature
+
+Two communities act as quasi-polities outside the Council's writ: **New Elturel** (Hellrider-administered) and **the K'liir** (githyanki self-governing). Both maintain effective borders the Flaming Fist crosses only cautiously.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/character.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/character.md
@@ -1,0 +1,44 @@
+---
+name: outer-city-character
+description: Texture of the Outer City — refugee grit, multicultural sprawl, and the boroughs that did not get their own file.
+---
+
+# Character
+
+The Outer City is what the Council of Four does not tax and the Flaming Fist does not patrol. Each borough is its own logic: refugee piety in New Elturel, caravan opportunism in Rivington, gnome workshops in Whitkeep, livestock yards in Stonyeyes, the alien drill-ground of the K'liir. They share only that none of them obey the Old Wall.
+
+## What you notice
+
+Everything that does not fit inside the city. Smoke from three continents over Sow's Foot. The orderly rows of Hellrider tents in New Elturel. Pale stone spires in the K'liir that look grown rather than built. Mud-brick walls in Little Calimshan, set with bottle-glass. Stables that never sleep in Blackgate. Shrines stacked four-deep in Twin Songs.
+
+## Boroughs not given their own file
+
+These districts have meaningful texture but did not warrant a full file in the first ingest pass. Pull them out into their own files when sessions need them.
+
+### Twin Songs
+
+Borough of shrines and small halls — Ilmater, Selûne, Helm, Tymora, Jergal, more. The **Church of Last Hope** shares an altar and a kitchen across three faiths. **Shrine Row (Siger's Walk)** gives every patron a candle. **The Open Secret** hosts controversial faiths under strict house rules. **Bellwater Steps** terraces the river for evening rites.
+
+### Sow's Foot
+
+The city in miniature, turned to full volume. **Pavilion of Plenty** anchors the market; **Hamhock's Slaughterhouse** supplies half the south bank; **Menagerie of Many** showcases beasts that may or may not be latched twice; **Council Tent** moves week to week as elders mediate disputes; **Cistern Twelve** is the rumor exchange. Rashemi, Shou, Calishite, lizardfolk, halfling, human — neighbors to each other if outsiders to the Gate.
+
+### Whitkeep
+
+Gnome ingenuity stitched to leather and dye. **Whitkeep Manor** is a communal hall and dormitory; the **Greenjack Tannery** is the largest local yard; the **Brass Brow Café** fuels morning design critiques and afternoon pamphleteering; **Maker's Lane** sells field-tested adventurer gadgets; **Stacks & Scraps** is the salvage yard.
+
+### Norchapel
+
+Quiet, devout, practical. The **Quiet Jacks' Hall** mediates disputes daily; **Marchel's Garden Market** runs Godsday; **Watchful Nest Shrines** keep candles burning dusk to dawn. Residents pool coin for extra watch rounds.
+
+### Stonyeyes
+
+The city's livestock belly. **Eastway Stockyards** by species; **Half-Hoof Tavern** is the hiring hall; **Creaky House** boards hands between jobs. Half-orc porters prized for strength and fairness.
+
+### Blackgate
+
+The Trade Way's doorstep. **Black Dragon Gate** for tolls and notice walls; **Stables Row** anchored by **Gelduth's Rest**; **Ironhands' Foundry** for shield-dwarf wagon gear; **Circle Grounds** for nightly caravan rings.
+
+## Pressure across the Outer City
+
+Toll hikes, smuggling routes that thread the bridge and the river, periodic Flaming Fist "security visits" indistinguishable from recruitment, and the daily reality that a Council policy made above the Old Wall can ruin a south-bank household by tomorrow's bell.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/little-calimshan.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/little-calimshan.md
@@ -1,0 +1,33 @@
+---
+name: little-calimshan
+description: Walled south-Faerûn enclave in the Outer City; jewelers, spice, oud music, and tradition.
+---
+
+# Little Calimshan
+
+Behind high mud-brick walls set with bottle-glass, Little Calimshan preserves a slice of the south: courtyards, fountains, saffron steam, oud music under lanterns. The gates open on a timetable and close on trouble; inside, elders guard tradition while traders count coin. Welcoming and watchful.
+
+## Notable stops
+
+- **Calim Jewel Emporium.** Courtyard showcases of filigree and fire-cut stones, appraised by a matriarch whose gaze weighs more than the scales. Commissions by appointment.
+- **The Oasis.** Tea-house built around an ever-flowing fountain; business over cardamom in daylight, stories and song after dark.
+- **Sun Gate.** Main gate and customs post; visiting hours posted, papers checked with courtesy and care.
+- **Copper Bazaar.** Market square for spices, textiles, oils, festival sweets; haggling expected, insults are not.
+- **House of Stories.** Elders' courtyard where travelers' tales and family histories are traded for tea.
+- **Loomstreet.** Tailors and weavers in shaded arcades; wedding cloth, traveling silks, hard-wearing caravan gear cut to fit.
+
+## What you notice
+
+Colorful awnings, patterned tiles, spices on the air, orderly queues at gate hours. Children perched on the wall at sunset; community guards with curved blades at street corners who nod if you mind your manners.
+
+## Who lives here
+
+Calishite families, jewelers and gem-cutters, spice sellers, caravan agents, young people walking the line between two homes, and community guards who know every face by name.
+
+## Etiquette and access
+
+Enter during posted hours or by invitation. Greet with a hand over the heart; accept tea if offered; keep hands off wares until invited. Dress modestly, speak plainly, and do not photograph or sketch people without permission.
+
+## Pressures
+
+Generational debates over how open to be with outsiders; occasional friction with nearby refugee markets; outside prejudice met with inside solidarity; quiet tug-of-war between community leaders and a local Guild crew that prefers to be helpful — for a percentage.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md
@@ -1,0 +1,30 @@
+---
+name: new-elturel
+description: Refugee borough on the south bank; Hellrider-administered, Ilmatari-fed, sunburst-pennanted.
+---
+
+# New Elturel
+
+Born of catastrophe and stubborn hope, New Elturel is a sprawling refugee borough of tents, timber shacks, and newly raised chapels on the south bank of the Chionthar. Its people are survivors first and citizens second — Hellriders on half pay, families clutching heirlooms, and priests who learned to triage faith and fever.
+
+## Notable stops
+
+- **The High Rider's Stand.** Open-air pavilion that serves as militia headquarters and council hall. Rosters posted at dawn; scouts report river news at dusk. HQ of the [Hellriders of New Elturel](../../../../20-Factions/hellriders-of-new-elturel/summary.md).
+- **The Sun-Blessed Chapel (Torm, Ilmater, Lathander).** Part sanctuary, part soup kitchen, part field hospital. Plain services, long lines, real comfort.
+- **Dawnmarket.** Refugee-run bazaar where farm tools, salvaged books, and "Last Light" loaves trade hands. Prices fair by custom, not by law.
+- **Memorial Row.** Carved wooden pillars etched with names that never made it home. Visitors leave white ribbons; locals leave silence.
+- **River Steps.** Terraced banks for washing, fishing, ferry musters to Rivington. Notice boards carry day-labor and escort postings.
+
+## Who lives here
+
+Elturian families, Hellrider veterans and trainees, Ilmatari volunteers, tieflings (heavily — most of the city's tiefling population concentrates here), and artisans rebuilding skills into livelihoods.
+
+## Etiquette and access
+
+Ask before offering coin (some take offense at charity, none refuse paid work). Don't mock uniforms held together by faith and thread. If you're Baldurian, lead with respect; politics can wait.
+
+## Pressures
+
+Supply gaps; riverborne sickness after floods; friction with nearby traders over prices and permits; Flaming Fist "security visits" that sometimes look like recruitment and sometimes like reminders of who holds the bridge.
+
+The [Plague of Remembrance](../../../../20-Factions/plague-of-remembrance/summary.md) frames Elturians here as scapegoats; the [Elturel Remembrance Society](../../../../20-Factions/elturel-remembrance-society/summary.md) recruits from Hellrider veterans. The [Followers of the Phoenix](../../../../20-Factions/followers-of-the-phoenix/summary.md) preach Karlach's gospel from a small shrine on the borough's edge.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/rivington.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/rivington.md
@@ -1,0 +1,28 @@
+---
+name: rivington
+description: South-bank gateway to Baldur's Gate; caravan yards, cheap inns, the Open Hand Temple, the Circus of the Last Days.
+---
+
+# Rivington
+
+Rivington is the south-bank gateway to Baldur's Gate: caravan yards, cheap inns, bustling stables, and markets that never quite close. Think of it as the city's foyer — less polished than the rooms beyond, but far friendlier if you arrive dusty and hungry.
+
+## Notable stops
+
+- **Open Hand Temple (Ilmater).** Refuge, bread, and a quiet corner to catch your breath. The notice board out front is the best place in Rivington to find honest work quickly.
+- **Circus of the Last Days.** Lucretious's traveling wonder — planar oddities, knife acts, stories that last longer than their ticket stubs. Pop-up, seasonal.
+- **Arfur's Mansion.** Prominent toy-maker's home and workshop with a cheery façade and nervous shutters. Locals have stories; few match.
+- **Southbank Market.** Sprawl of canvas-roofed stalls: tack, travel rations, second-hand armor, roadside cures of arguable merit.
+- **Bridgefoot Commons.** Square before the ascent to Wyrm's Crossing. Porters at first bell; rumor peddlers at last light.
+
+## Who lives here
+
+Innkeepers, stable owners, drovers, day-laborers, retired caravan guards, and families who feed the road.
+
+## Etiquette and access
+
+Peace-tie blades near the checkpoints, keep travel papers handy, tip your porter before you need him again. Bargain, but don't haggle a family's supper into thin air.
+
+## Pressures
+
+Toll hikes squeezing margins; smuggling routes that skirt the bridge under cover of ferries; pickpocket crews hunting festival days; periodic Flaming Fist crackdowns that punish the honest and miss the clever.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/the-kliir.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/the-kliir.md
@@ -1,0 +1,31 @@
+---
+name: the-kliir
+description: Githyanki exile encampment in the Outer City; angular tents, psionic gantries, pale stone spires.
+---
+
+# The K'liir
+
+Raised after the Absolute Crisis (1496 DR) by githyanki who chose the Gate over the Astral, the K'liir is a disciplined enclave of angular tents, psionically braced gantries, and pale stone spires that look grown rather than built. It is part drill yard, part embassy, and entirely itself. HQ of [The Unchained](../../../../20-Factions/unchained/summary.md), commanded by **K'laar the Unshackled**.
+
+## Notable stops
+
+- **The Proving Ground.** A warded plaza where martial and psionic forms are practiced in perfect cadence. Observers permitted along marked lines; crossing them ends your tour.
+- **Psionic Resonator.** Faceted crystal obelisk used for long-range communion and scrying. Thrums like a distant hive; guides ask for silence nearby.
+- **The Concord Pavilion.** Canvas-and-bone hall where emissaries parley. Appointments only; translated courtesy is the rule.
+- **Astralwrights' Shed.** Spartan stall trading in githyanki-forged steel, void-cured leathers, and curious climbing gear prized by daring locals.
+
+## What you notice
+
+Geometric pennants that barely move in the wind; silent formations running spear drills; a low crystalline hum at the center of camp that fades if you listen too hard. Visitors are watched, not welcomed or shunned — assessed.
+
+## Who lives here
+
+Orpheus-loyal veterans, an austere cadre of trainers, a handful of Sword Coast intermediaries, and a small cohort of Gate-born youths learning gith forms with careful permission.
+
+## Etiquette and access
+
+Announce yourself at the perimeter post; wait to be acknowledged. Do not mimic salutes or practice forms uninvited. Sheath steel, shield thoughts if you can, and accept that questions will be answered with fewer words than you asked.
+
+## Pressures
+
+Tense politics with Upper City skeptics and Outer City gawkers; theft attempts by collectors chasing astral curios; occasional feuds with mercenaries who mistake restraint for weakness. The K'liir answers slights as a unit — and is utterly hostile to any hint of mind-flayer activity, which puts the [Hands of the Absolute](../../../../20-Factions/hands-of-the-absolute/summary.md) at the top of their target list.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/tumbledown-and-floodway.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/tumbledown-and-floodway.md
@@ -1,0 +1,32 @@
+---
+name: tumbledown-and-floodway
+description: Cemeteries and stonemasons' yards on the bluffs above; flood-prone tenements below.
+---
+
+# Tumbledown & The Floodway
+
+Beyond the river bluffs, cemeteries and stonemasons' yards spread like a quiet city of their own. **Tumbledown's** grief is orderly: funerary trades, carvers' sheds, sober processions. The **Floodway** below is the opposite — low ground of tilting tenements and boardwalk lanes that drown after a hard rain and rise again, stubborn as reeds.
+
+## What you notice
+
+In Tumbledown: wind through grave cypress, chisel taps from dawn to dusk, stone markers stacked like books in a patient library. In the Floodway: laundry lines above knee-deep streets, plankwalks over brown water, children who can pole a skiff before they can write.
+
+## Notable stops
+
+- **Candulhallow's Tombstones.** Best-known carvers' yard, equal parts workshop and open-air gallery. Epitaphs range from poetry to practical warnings. Front for the [Gravekeepers](../../../../20-Factions/gravekeepers/summary.md), led by Old Man Hemlock.
+- **Cliffgate.** Fog-wreathed gate linking the bluffs to the Lower City. The drop beside the road is sheer; the reputation for muggings is earned.
+- **The Lych-Steps.** Old stone stairs descending toward the Floodway, used for processions in better weather and quick exits in worse.
+- **Highwater Wharf.** Raised dock for skiffs and ferries when the Floodway lives up to its name; rumor boards post missing-person notes after storms.
+- **Stonecutters' Row.** Tool shops, stencil sellers, and a mason-priests' refectory that serves hearty noon meals to anyone who worked a morning.
+
+## Who lives here
+
+Morticians, stonecutters, gravediggers, quiet families with steady hands. In the Floodway, laborers who can't afford higher ground but will not leave their neighbors.
+
+## Etiquette and access
+
+Keep voices low among graves, don't lean on markers, step wide for processions. In the Floodway, ask a local before trying a side path — today's dry plank was yesterday's plank boat.
+
+## Pressures
+
+Grave robbers; sinkholes after long rains; tenants displaced by the third flood in a month; the occasional "restless dead" report the Row shrugs off until a priest stops shrugging. The [Cult of the Returning Lord](../../../../20-Factions/cult-of-the-returning-lord/summary.md) consecrates altars here when the Gravekeepers aren't watching.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md
@@ -1,0 +1,28 @@
+---
+name: wyrms-crossing
+description: Bridge-and-fortress neighborhood across the Chionthar; Wyrm's Rock Fortress; tolls, taverns, and traffic.
+---
+
+# Wyrm's Crossing
+
+Part bridge, part neighborhood. Wyrm's Crossing strides the Chionthar on two great spans that meet at **Wyrm's Rock Fortress**. Shops and tenements are built right into the stonework; from dawn to curfew the roadway is a rolling caravan of carts, pilgrims, and news. The Flaming Fist runs the drawbridges, the tolls, and the temper of the place.
+
+## Notable stops
+
+- **Wyrm's Rock Fortress.** The [Flaming Fist's](../../../../20-Factions/flaming-fist/summary.md) bridgehead and HQ — permits checked, disputes settled, drawbridges lifted with impressive indifference to your schedule. A symbol of strength that no longer reflects reality. Public notices on the gate post road conditions and bounty bills.
+- **Sharess' Caress.** Festhall-inn with velvet manners and surprisingly good security. Whispered conversations in curtained booths often matter more than the entertainment.
+- **Danthelon's Dancing Axe.** Quality arms shop with an immaculate reputation and a quiet back room where the right kind of questions sometimes find answers. Known [Harper](../../../../20-Factions/harpers/summary.md) front.
+- **Fraygo's Flophouse.** Cheapest pillow on the bridge (2 sp/night) and the loudest snores in the city. Bring your own lock.
+- **Underbridge Piers.** Steps down to boat landings used by ferries, fishermen, and — on foggy nights — people who prefer not to cross at street level.
+
+## Who lives here
+
+Innkeepers, stall vendors, toll clerks, off-duty Fist, scribes-for-hire, families who've held lofts since before the last repair, and a floating population between jobs on either bank.
+
+## Etiquette and access
+
+Have coin ready, peace-tie weapons when asked, keep to the left if you're on foot, do not block a drawbridge lane — fines are instant. Expect bag checks during high alert.
+
+## Pressures
+
+Toll hikes; protection "offers" to shopkeepers; pickpocket crews on festival days; smuggling runs that slip under the spans by night. When the bridge locks down, the whole south bank feels it.

--- a/30-Places/sword-coast/baldurs-gate/undercity/README.md
+++ b/30-Places/sword-coast/baldurs-gate/undercity/README.md
@@ -1,0 +1,17 @@
+---
+name: undercity
+description: The sewer labyrinth and the Undercellar smugglers' market beneath the Wide.
+---
+
+# Undercity
+
+Beneath the streets lies a city in darkness. Two distinct subterranean networks share the territory and the term:
+
+- [character.md](character.md) — texture and overview.
+- [the-undercellar.md](the-undercellar.md) — the clandestine elite market beneath the Wide.
+
+The **Undercity proper** — the sewer labyrinth — is the [Guild's](../../../../20-Factions/guild/summary.md) primary domain. Its main heavily defended **Guildhall** sits in a fortified sewer nexus accessible only through routes the Guild maintains by force.
+
+## Pressures
+
+The Undercity is also home to monstrous creatures and outcasts; ancient crypts and forgotten temples open onto the tunnels. The [Cult of the Returning Lord](../../../../20-Factions/cult-of-the-returning-lord/summary.md) consecrates Bhaalite altars in disused chambers; the [Silent Shroud](../../../../20-Factions/silent-shroud/summary.md) hunts the lost sanctums of Shar in the deeper levels; the [Hands of the Absolute](../../../../20-Factions/hands-of-the-absolute/summary.md) listen for psychic echoes in spaces the Netherbrain once touched.

--- a/30-Places/sword-coast/baldurs-gate/undercity/character.md
+++ b/30-Places/sword-coast/baldurs-gate/undercity/character.md
@@ -1,0 +1,31 @@
+---
+name: undercity-character
+description: The sewer-and-crypt labyrinth beneath Baldur's Gate; Guild infrastructure, monster country, and the deep cult shrines.
+---
+
+# Character
+
+The Undercity is the city's other half: a labyrinth of sewer tunnels, ancient cisterns, forgotten crypts, and the buried foundations of districts the surface long forgot.
+
+## What you notice
+
+Cold air that always smells faintly of brackish water. Worked stone that changes hands every fifty feet — Balduran-era brick, post-Iron-Crisis arches, the occasional pre-human chiseled wall left over from whatever stood here before. Lantern light dies fast; sound carries oddly. Marks chalked at junctions in three different scripts: Guild, Watch, and a third no one will name.
+
+## Who moves through
+
+- **Guild crews** — by far the most common presence. Smugglers, couriers, Ward-Boss enforcers, and the [River-Rats](../../../../20-Factions/river-rats/summary.md) running goods through Brampton-side outflows.
+- **Monster country** — otyughs, oozes, dire rats, ghouls, and worse where the tunnels touch old crypts.
+- **Cult cells** — Bhaalite, Sharran, and Absolute-remnant all maintain Undercity shrines.
+- **Independent scavengers** — Arcane refuse from Sorcerous Sundries' overflow chambers; Steel Watch fragments from sealed Foundry corridors.
+
+## Who lives down here
+
+A small permanent population: outcasts, fugitives, sewer-workers in the Council's nominal employ, and a few hermits who prefer dark and silence to anything the surface offers. Refugees during freezes; a recurring problem when the Floodway floods.
+
+## The Guildhall
+
+The Guild's main HQ is a fortified nexus in the sewers — defended by murder-holes, traps, and ward-magic, accessible only through Guild-maintained routes. The Guild treats the Undercity as its sovereign territory in a way that is functionally true: the Flaming Fist will not enter without a major operation, and major operations are politically expensive.
+
+## Etiquette and access
+
+There is no official guide. Going in without a Guild escort or a very specific reason is suicide that takes time. If you do go in, don't open sealed doors, don't read inscriptions you can't read, and don't follow lights you can't account for.

--- a/30-Places/sword-coast/baldurs-gate/undercity/the-undercellar.md
+++ b/30-Places/sword-coast/baldurs-gate/undercity/the-undercellar.md
@@ -1,0 +1,22 @@
+---
+name: the-undercellar
+description: The clandestine elite market beneath the Wide; rare poisons, forbidden scrolls, and worse.
+---
+
+# The Undercellar
+
+Specifically located beneath **the Wide** in the Upper City, the Undercellar is a network of ancient, vaulted cellars used as a clandestine marketplace where the city's elite can purchase illegal goods — rare poisons, forbidden scrolls, slaves — delivered by the [Guild](../../../../20-Factions/guild/summary.md) through secret tunnels that bypass the city's walls entirely.
+
+## How it works
+
+- **Discreet stairwells.** A handful of colonnades around the Wide conceal steps down. Locals deny they exist; the Watch enforces nothing.
+- **Members and patrons.** Patriar buyers, foreign Kontor agents, conspirators, and a quiet rotation of professional intermediaries.
+- **Smugglers' tunnels.** The Guild's deepest contraband moves directly from the river caves through Undercellar-side passages — bypassing every gate the Flaming Fist tolls.
+
+## What is sold
+
+Rare poisons (often Alchemists' Company surplus diverted through unofficial channels), forbidden scrolls, slaves (a Zhentarim rather than Guild specialty, but the Undercellar accepts both), restricted alchemical reagents, and the kinds of artifacts no licensed broker will touch.
+
+## Pressure
+
+The Undercellar is the friction point where Upper City respectability meets Lower City contraband. Patriar reputations have been broken by an inconvenient witness on a stairwell; Ward Bosses have been promoted by delivering the right scroll to the right buyer. The [Bibliophile](../../../../20-Factions/bibliophile/summary.md) trades information about who bought what; the [Knights of the Shield](../../../../20-Factions/knights-of-the-shield/summary.md) recruit here.

--- a/30-Places/sword-coast/baldurs-gate/upper-city/README.md
+++ b/30-Places/sword-coast/baldurs-gate/upper-city/README.md
@@ -1,0 +1,23 @@
+---
+name: upper-city
+description: Walled, magically-lit district atop the bluff; patriar manors, civic halls, and exclusive markets.
+---
+
+# Upper City
+
+A world apart, atop the bluff and inside its own magically-lit stone walls. The Old Wall and a handful of gates separate it from the Lower City below; the Watch enforces a level of safety unimaginable downhill. Politics are mostly conducted in private salons and the High Hall.
+
+## Index
+
+- [character.md](character.md) — overall vibe and how the wealth shows.
+- [manorborn.md](manorborn.md) — the patriar quarter; manors, walled gardens, the Helm and Cloak.
+- [temples-district.md](temples-district.md) — the civic-religious boulevard; High Hall sits here.
+- [the-wide.md](the-wide.md) — the great licensed market square; Undercellar entrances rumored beneath.
+
+## Access
+
+Entry is by Watch checkpoint. The principal gate from the Lower City is **Old Baldur's Gate** in the Old Wall — a 5 cp passage fee by day, sealed by night. Patriar staff and chartered traders pass with papers; everyone else needs a sponsor.
+
+## Pressure
+
+The greatest dangers are not violent. Inheritance feuds, blackmail, embezzlement, reputations rearranged like chess pieces — all the crimes that leave no bruises.

--- a/30-Places/sword-coast/baldurs-gate/upper-city/character.md
+++ b/30-Places/sword-coast/baldurs-gate/upper-city/character.md
@@ -1,0 +1,29 @@
+---
+name: upper-city-character
+description: Vibe and texture of the Upper City — clean stone, magical light, ritualized politics.
+---
+
+# Character
+
+Clean magically-lit streets, historic manors, exclusive boutiques, grand temples. The patriar families and the new-money elite live in splendid isolation; their primary concerns are social standing and political maneuvering.
+
+## What you notice
+
+Uniformed house guards at every gate; servant bell-pulls chiming behind ivy; coach wheels whispering over swept stone. Beggars and hawkers are politely redirected at the Old Wall — the noise of the Lower City seems to stop at the lintel.
+
+## Mood
+
+Theatrical and very aware that you are visiting. Money here is performed as taste. Citrus, beeswax, and incense displace the harbour smells from below.
+
+## Power, in one paragraph
+
+The Watch keeps order, but the real instruments of power are dinner invitations, garden walks, and Helm-and-Cloak booth conversations. Crimes that matter here are paper crimes — forged seals, bought titles, falsified inheritance lines. Violence is a vulgarity employed only when discretion fails.
+
+## Who lives here
+
+Old families with older ledgers; new fortunes buying old manners; stewards, legists, and armies of staff who keep the façade flawless. A few merchant princes who built fortunes in the Decade of Reconstruction now own manors next door to families that have held theirs for centuries.
+
+## See also
+
+- [manorborn.md](manorborn.md), [temples-district.md](temples-district.md), [the-wide.md](the-wide.md).
+- [governance.md](../governance.md) — High Hall, Council, Parliament.

--- a/30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md
+++ b/30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md
@@ -1,0 +1,27 @@
+---
+name: manorborn
+description: The patriar quarter — walled gardens, hushed courtyards, manors older than most nations.
+---
+
+# Manorborn
+
+If prestige had an address, it would be here. A quiet world of walled gardens, hushed courtyards, and manors whose names are older than most nations. Streets are broad and freshly swept; door knockers gleam; the air smells faintly of citrus and beeswax.
+
+## Notable stops
+
+- **The Helm and Cloak.** Invitation-only club and inn where civic gossip wears perfume. Aristocratic suite ~40 gp/night by invitation; politics matter more than the dining.
+- **Watchful Shield Shrine (Helm).** Marble, brass lamps, brassier discretion. The Watch and well-heeled petitioners come for blessings that double as alibis.
+- **Patriar Garden Walks.** On festival eves, a handful of estates open their front gardens for strolling. You will not see their vaults; you will see who is courting whom.
+- **The Limehouse Conservatory.** Glass-roofed gallery of imported fruit trees and private recitals; tickets are scarce and status is the point.
+
+## Who lives here
+
+Old patriar families, new fortunes buying old manners, stewards and legists, armies of household staff. The **Bloomridge Park Manor** of [Western Gate Trading Company](../../../../20-Factions/western-gate-trading-company/summary.md) — Archduke Lyra Silvershield's seat — is the de facto Council seat at the moment.
+
+## Access and etiquette
+
+Dress neatly, sheath blades, speak softly. Entry after dusk typically requires papers or a resident sponsor. Guards are polite until you give them a reason not to be.
+
+## Pressures
+
+Inheritance feuds, fortunes stretched thinner than the plaster, and the kind of crimes that leave no bruises: blackmail, quiet embezzlement, and reputations arranged like chess pieces. The [Knights of the Shield](../../../../20-Factions/knights-of-the-shield/summary.md) recruit dispossessed patriars here.

--- a/30-Places/sword-coast/baldurs-gate/upper-city/temples-district.md
+++ b/30-Places/sword-coast/baldurs-gate/upper-city/temples-district.md
@@ -1,0 +1,27 @@
+---
+name: temples-district
+description: The civic-religious boulevard — bell towers, the High Hall, processions threading past government façades.
+---
+
+# The Temples District
+
+The Upper City's public face: bell towers, broad steps, and processions threading past government façades. Piety and policy share the same boulevard; salvation and permits are both stamped here.
+
+## Notable stops
+
+- **High Hall.** Council chambers, public hearings, and a civic museum's worth of triumphal murals. The seat of both Peerages of the [Parliament of Peers](../../../../20-Factions/parliament-of-peers/summary.md) and of the [Council of Four](../../../../20-Factions/council-of-four/summary.md). Petitioners arrive at dawn.
+- **High House of Wonders & Hall of Wonders (Gond).** Part workshop, part marvel-hall. Whirring exhibits, guided tours, a tasteful donation box that is never empty.
+- **Lady's Hall (Tymora).** Bright, busy, lucky by design. Merchants and adventurers come here to hedge fate before big ventures.
+- **Stormshore Tabernacle.** A many-faith sanctuary with rotating rites. Priests debate theology in the morning and share bread recipes in the afternoon.
+
+## Who lives here
+
+Prelates, advocates, archivists, and functionaries who can recite bylaws by heart. Pilgrims and petitioners swell the crowds dawn to dusk.
+
+## Etiquette and access
+
+Peace-tie weapons. Small offerings at most shrines, larger ones if you are asking for anything remarkable. Lines are long; impatience earns nothing.
+
+## Pressures
+
+Competition between temples for endowments; relic thefts smoothed over to avoid scandal; bureaucratic turf wars where a misplaced seal can stall a life for weeks. The [Silent Shroud](../../../../20-Factions/silent-shroud/summary.md) and the [Cult of the Returning Lord](../../../../20-Factions/cult-of-the-returning-lord/summary.md) probe the public temples for converts and grievances.

--- a/30-Places/sword-coast/baldurs-gate/upper-city/the-wide.md
+++ b/30-Places/sword-coast/baldurs-gate/upper-city/the-wide.md
@@ -1,0 +1,27 @@
+---
+name: the-wide
+description: The grand licensed market square; disciplined riot by day, lantern-lit emptiness by night, Undercellar beneath.
+---
+
+# The Wide
+
+The city's grand market square. A disciplined riot by day and a stage set by night. Licensed stalls unfurl at first bell — silks, spices, spell components, notarized contracts — then fold away at dusk, leaving a lantern-lit emptiness that makes your steps sound very loud.
+
+## Notable stops
+
+- **Licensed Stalls and Factors' Arcades.** The best place above the Wall to compare wares without risking your skin. Haggling is expected; receipts are essential.
+- **The Weighhouse.** Public scales where disputes are settled in the open; the scale's honesty is legendary and loudly defended.
+- **Auction Rostrum.** Estate lots, ship cargo overages, the occasional miscellany of interest. Come early for a seat; later for the rumors.
+- **Discrete Stairwells.** Locals swear a few colonnades conceal steps to the **Undercellar** — the smugglers' market beneath the Upper City. Officially nonexistent. See [undercity/](../undercity/README.md).
+
+## Who lives here
+
+Few. The Wide is for business. By evening, only resident shopkeepers, sweepers, and patrols remain.
+
+## Etiquette and access
+
+Only licensed sellers may trade here. Keep purses close, papers closer, and an eye on closing bell; after dark the square is cleared with brisk efficiency.
+
+## Pressures
+
+License disputes; counterfeit seals (a perennial Worshipful-Company concern); helpful middlemen who attach to your purchases like barnacles; after-hours deliveries that pass unnoticed until they don't. The [Guild's](../../../../20-Factions/guild/summary.md) Undercellar tunnels surface here through entries no one will officially confirm.

--- a/30-Places/sword-coast/demographics.md
+++ b/30-Places/sword-coast/demographics.md
@@ -1,0 +1,24 @@
+---
+name: sword-coast-demographics
+description: Regional ancestry mix and post-crisis population movements across the Sword Coast.
+---
+
+# Sword Coast Demographics
+
+Region-scale demographic notes; city-level texture lives in `baldurs-gate/character.md` and the wards.
+
+## Pressures since 1492 DR
+
+- **Elturian diaspora.** The Fall of Elturel (1494 DR) emptied a major regional city. Tens of thousands of refugees — disproportionately tieflings — flowed down the Coast Way into the Outer City of Baldur's Gate, founding **New Elturel** and reshaping the south-bank borough. See [10-Setting/peoples/elturian-diaspora.md](../../10-Setting/peoples/elturian-diaspora.md).
+- **Foreign nationals.** The Great Bargain (1493 DR) seeded permanent Amnian, Waterdhavian, Sembian, and Lantaner populations inside the walled Kontor enclaves. They live and trade among Baldurians but largely outside Baldurian law.
+- **Githyanki exile.** A faction of Prince Orpheus's rebellion settled the K'liir in 1496 DR — about 1% of the city's headcount, but radically over-represented in martial and psionic capability.
+
+## Regional ancestry mix
+
+Baldur's Gate's mix is a fair proxy for the urban Sword Coast: ~70% human, ~8% tiefling (concentrated in New Elturel), ~6% dwarf, ~5% elf and half-elf, ~4% halfling and gnome, ~1% githyanki, ~6% other (dragonborn, half-orcs, lizardfolk, others).
+
+Rural Hansa polities skew more heavily human and dwarf, with halflings clustered around the Sword Coast farming belt. See `baldurs-gate/character.md` for in-city distribution.
+
+## Movement
+
+The Coast Way and the Trade Way are the two great migration spines. Caravans roll into Eastway (city-side, Lower City) and Blackgate / Rivington (Outer City) at all hours; ferries link Rivington and the south bank to the Lower City wharves. Population flows are weighted toward the Gate; few leave.

--- a/30-Places/sword-coast/polities.md
+++ b/30-Places/sword-coast/polities.md
@@ -1,0 +1,24 @@
+---
+name: sword-coast-polities
+description: Short index of polities and alliances active across the Sword Coast region in 1502 DR.
+---
+
+# Sword Coast Polities
+
+Index only — analytical content lives in [10-Setting/polities/](../../10-Setting/polities/).
+
+## Trade alliances
+
+- **Sword Coast Hansa** — informal, Baldur's-Gate-centric trading bloc binding mercantile cities and towns through standardized tariffs, shared commercial law, and mutual defense pacts. See [10-Setting/polities/sword-coast-hansa.md](../../10-Setting/polities/sword-coast-hansa.md).
+- **Lords' Alliance** — formal, Waterdeep-led mutual-defense pact; reaches the Gate via the Waterdhavian Kontor. Out-of-scope for this dossier.
+
+## Major cities and towns
+
+- **Baldur's Gate** — Hansa head; see [baldurs-gate/](baldurs-gate/README.md).
+- **Waterdeep** — northern terminus, City of Splendors. (See dossier #21.)
+- **Athkatla, Selgaunt, Lantan** — represented in Baldur's Gate via the Foreign Kontors (`20-Factions/{amnian,sembian,lantaner}-kontor/`).
+- **Daggerford, Beregost, Nashkel** — Hansa-aligned smaller polities, ports of call along the Coast Way and the Trade Way.
+
+## Outer City polities
+
+The Outer City of Baldur's Gate hosts effective polities-in-miniature: **New Elturel** (Hellrider-administered refugee borough) and **the K'liir** (githyanki exile encampment). Both are legally outside the Council of Four's writ. See [baldurs-gate/outer-city/](baldurs-gate/outer-city/README.md).

--- a/40-Timeline/README.md
+++ b/40-Timeline/README.md
@@ -7,3 +7,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the per-week layout.
 ## Index
 
 - [calendar.md](calendar.md) — week 0 anchor and DR date conventions.
+- [history.md](history.md) — pre-week-0 dated events (founding through 1502 DR present-day anchor).

--- a/40-Timeline/history.md
+++ b/40-Timeline/history.md
@@ -1,0 +1,36 @@
+---
+name: timeline-history
+description: Pre-week-0 dated events from the Baldur's Gate dossier (Chapter 3) and surrounding setting history.
+---
+
+# History (pre-week-0)
+
+Dated events anchoring the campaign world before week 0 (early spring, **1502 DR** — see [calendar.md](calendar.md)). Story-level analysis lives in [10-Setting/history/](../10-Setting/history/README.md); this file is the chronological index.
+
+## Chronology
+
+| Year (DR) | Event | Note |
+| --- | --- | --- |
+| c. 1068 | Founding of Baldur's Gate | Balduran walls Gray Harbour (formerly Loklee). |
+| 1358 | Time of Troubles | Bhaal sires mortal children before his foreseen death. |
+| 1368 | Iron Crisis (BG I) | Sarevok Anchev tries to spark war with Amn; stopped by Abdel Adrian. |
+| 1369 | Bhaalspawn Crisis (BG II / Throne of Bhaal) | Abdel Adrian forsakes the Throne. |
+| 1370 | Founding of the Flaming Fist | Grand Duke Eltan charters the mercenary company. |
+| 1385 | Spellplague | Mystra assassinated; trade and politics disrupted. |
+| 1477–78 | The Emperor's Return | Balduran-as-mind-flayer dominates Duke Stelmane. |
+| 1482 | Murder in Baldur's Gate | Viekang kills Abdel Adrian; Bhaal resurrected. |
+| 1491 | Prelude to Crisis | Vanthampur dies; Ravengard disappears in the Fall of Elturel. |
+| **1492** | **Absolute Crisis** (BG3) | Netherbrain destroyed. See [absolute-crisis](../10-Setting/history/absolute-crisis.md). |
+| 1493 | The Great Bargain | Foreign Kontors chartered. See [great-bargain](../10-Setting/history/great-bargain.md). |
+| 1494 | Fall of Elturel | City dragged to Avernus; Elturian diaspora floods the Gate. See [elturian-diaspora](../10-Setting/peoples/elturian-diaspora.md). |
+| 1496 | The K'liir Established | Orpheus-loyal githyanki under K'laar settle the Outer City. |
+| 1497 | Parliament Reformed | Peerages of Blood and Coin created. See [1497-reformation](../10-Setting/history/1497-reformation.md). |
+| **1502** | **Present Day** | Week 0 sits in early spring of this year. |
+
+## Week-0+ events
+
+The dossier lists no events at or after week 0. Session-driven content fills `40-Timeline/week_N/events.md` as play unfolds.
+
+## Source
+
+Dossier Chapter 3 ("A Timeline of Baldur's Gate"), cross-referenced to Chapters 1, 2, 4–6.


### PR DESCRIPTION
## Summary

Routes the ~1,500-line Baldur's Gate dossier into the knowledge base across four folders:

- **00-Campaign-Frame/** — three inferred-principle files (`economics.md`, `power.md`, `class-and-survival.md`) distilled from the dossier as evergreen world-physics, not transcribed paragraphs.
- **10-Setting/** — `CONTRIBUTING.md` plus populated `history/`, `polities/`, `peoples/`, `economy/` (8 world-fact files: Absolute Crisis, Decade of Reconstruction, Great Bargain, 1497 Reformation, Sword Coast Hansa, Worshipful Company system, Elturian diaspora, cost of living).
- **40-Timeline/history.md** — every dated Chapter 3 event in chronological order; week-0+ events deferred to per-week folders.
- **30-Places/sword-coast/baldurs-gate/** — full city tree: region skeleton, city-level files, and all four ward folders (Upper / Lower / Outer / Undercity) with district sub-files for the high-signal locations.

## Constraints honored

- Every file <500 words, frontmatter present, internal links resolve.
- Faction prose stays in `20-Factions/` — Places only cross-link. Part V "Directory of Influence" verified against the existing 56 folders; zero gaps, audit note added.

## Test plan

- [ ] Confirm region slug `sword-coast` matches the convention you want and the in-flight `#20` (Sea of Swords) PR can stack on top.
- [ ] Skim `00-Campaign-Frame/` to confirm the three principles read as evergreen world-truths, not chapter summaries.
- [ ] Verify `30-Places/sword-coast/baldurs-gate/factions.md` has no prose duplication with `20-Factions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)