### PR TITLE
Week 0: faction activity, timeline, place events, party canon

### DIFF
--- a/20-Factions/amnian-kontor/README.md
+++ b/20-Factions/amnian-kontor/README.md
@@ -6,3 +6,4 @@ Slice of a mighty mercantile empire dominating Baldur's Gate through banking, de
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: vorlamin-athar.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/amnian-kontor/activity/README.md
+++ b/20-Factions/amnian-kontor/activity/README.md
@@ -1,0 +1,7 @@
+# Amnian Kontor — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — finalize-foreclosure-on-the-hlath-estate.

--- a/20-Factions/amnian-kontor/activity/week_0/README.md
+++ b/20-Factions/amnian-kontor/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Amnian Kontor — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [finalize-foreclosure-on-the-hlath-estate.md](finalize-foreclosure-on-the-hlath-estate.md)

--- a/20-Factions/amnian-kontor/activity/week_0/finalize-foreclosure-on-the-hlath-estate.md
+++ b/20-Factions/amnian-kontor/activity/week_0/finalize-foreclosure-on-the-hlath-estate.md
@@ -1,0 +1,19 @@
+---
+name: finalize-foreclosure-on-the-hlath-estate
+faction: amnian-kontor
+week: 0
+discovery_dc: 10
+dc: 5
+success: false
+public: false
+---
+
+# Finalize Foreclosure on the Hlath Estate
+
+[Consul Vorlamin Athar's](../../people/vorlamin-athar.md) legal agents finalize the foreclosure on the Hlath patriar estate in [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md). The family, ruined by gambling debts owed to Amnian lenders, is quietly and unceremoniously evicted. The Kontor now owns a prime piece of Upper City real estate.
+
+## See also
+
+- [Amnian Kontor](../../summary.md)
+- [Peerage of Blood](../../../peerage-of-blood/summary.md) — Lord Hlath was a patriar; Lord Corin Durinbold later files an injunction against the resale.
+- [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md)

--- a/20-Factions/baldurs-mouth/README.md
+++ b/20-Factions/baldurs-mouth/README.md
@@ -7,3 +7,4 @@ The city's broadsheet, edited by Ettvard Needle; for-hire front-page coverage.
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: ettvard-needle, the-interim-management-board.
 - [associations/](associations/) — Items, holdings, vehicles (credential-of-balduran, heapside-print-shop).
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/baldurs-mouth/activity/README.md
+++ b/20-Factions/baldurs-mouth/activity/README.md
@@ -1,0 +1,7 @@
+# Baldur's Mouth — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — print-a-pro-consortium-puff-piece.

--- a/20-Factions/baldurs-mouth/activity/week_0/README.md
+++ b/20-Factions/baldurs-mouth/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Baldur's Mouth — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [print-a-pro-consortium-puff-piece.md](print-a-pro-consortium-puff-piece.md)

--- a/20-Factions/baldurs-mouth/activity/week_0/print-a-pro-consortium-puff-piece.md
+++ b/20-Factions/baldurs-mouth/activity/week_0/print-a-pro-consortium-puff-piece.md
@@ -1,0 +1,19 @@
+---
+name: print-a-pro-consortium-puff-piece
+faction: baldurs-mouth
+week: 0
+discovery_dc: 0
+dc: 5
+success: false
+public: true
+---
+
+# Print a Pro-Consortium Puff Piece
+
+For a hefty bag of coin from Matron [Lyra Silvershield](../../../western-gate-trading-company/people/lyra-silvershield.md), editor Ettvard Needle runs a front-page story in the Baldur's Mouth praising the [Western Gate Trading Company](../../../western-gate-trading-company/summary.md) for "bravely taming the wilderness" to provide jobs and resources for the city.
+
+## See also
+
+- [Baldur's Mouth](../../summary.md)
+- [Western Gate Trading Company](../../../western-gate-trading-company/summary.md)
+- [people/ettvard-needle.md](../../people/ettvard-needle.md)

--- a/20-Factions/bibliophile/README.md
+++ b/20-Factions/bibliophile/README.md
@@ -6,3 +6,4 @@ Information broker (Nansi Gretta) selling intel to the highest bidder.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: nansi-gretta.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/bibliophile/activity/README.md
+++ b/20-Factions/bibliophile/activity/README.md
@@ -1,0 +1,7 @@
+# The Bibliophile — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — sell-information-on-a-cheating-merchant.

--- a/20-Factions/bibliophile/activity/week_0/README.md
+++ b/20-Factions/bibliophile/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Bibliophile — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [sell-information-on-a-cheating-merchant.md](sell-information-on-a-cheating-merchant.md)

--- a/20-Factions/bibliophile/activity/week_0/sell-information-on-a-cheating-merchant.md
+++ b/20-Factions/bibliophile/activity/week_0/sell-information-on-a-cheating-merchant.md
@@ -1,0 +1,19 @@
+---
+name: sell-information-on-a-cheating-merchant
+faction: bibliophile
+week: 0
+discovery_dc: 20
+dc: 10
+success: true
+public: false
+---
+
+# Sell Information on a Cheating Merchant
+
+[Nansi Gretta's](../../people/nansi-gretta.md) network sells proof to a [Chionthar Consortium](../../../chionthar-consortium/summary.md) member that his partner is secretly making side deals with the [Sembian Kontor](../../../sembian-kontor/summary.md). The information is sold for a high price, and the resulting fallout benefits Gretta's other clients.
+
+## See also
+
+- [The Bibliophile](../../summary.md)
+- [Chionthar Consortium](../../../chionthar-consortium/summary.md)
+- [Sembian Kontor](../../../sembian-kontor/summary.md)

--- a/20-Factions/carnival-of-whispers/README.md
+++ b/20-Factions/carnival-of-whispers/README.md
@@ -6,3 +6,4 @@ Fey-pact cult using illusion and abduction to harvest emotional residue for thei
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: mister-smiles.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/carnival-of-whispers/activity/README.md
+++ b/20-Factions/carnival-of-whispers/activity/README.md
@@ -1,0 +1,7 @@
+# The Carnival of Whispers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — abduct-a-passionate-soul.

--- a/20-Factions/carnival-of-whispers/activity/week_0/README.md
+++ b/20-Factions/carnival-of-whispers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Carnival of Whispers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [abduct-a-passionate-soul.md](abduct-a-passionate-soul.md)

--- a/20-Factions/carnival-of-whispers/activity/week_0/abduct-a-passionate-soul.md
+++ b/20-Factions/carnival-of-whispers/activity/week_0/abduct-a-passionate-soul.md
@@ -1,0 +1,18 @@
+---
+name: abduct-a-passionate-soul
+faction: carnival-of-whispers
+week: 0
+discovery_dc: 20
+dc: 15
+success: true
+public: false
+---
+
+# Abduct a 'Passionate' Soul
+
+The abduction attempt in [Bloomridge](../../../../30-Places/sword-coast/baldurs-gate/lower-city/bloomridge.md) turns into a noisy street fight as the targeted poet, a skilled fencer, fights back. The clowns flee after the poet wounds one and raises the alarm. The Bloomridge neighborhood is now on high alert for sinister clowns, making future abductions in the area far more difficult.
+
+## See also
+
+- [The Carnival of Whispers](../../summary.md)
+- [Bloomridge](../../../../30-Places/sword-coast/baldurs-gate/lower-city/bloomridge.md)

--- a/20-Factions/chionthar-consortium/README.md
+++ b/20-Factions/chionthar-consortium/README.md
@@ -6,3 +6,4 @@ Old-money Baldurian merchant bloc controlling river trade along the Chionthar.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: joric-the-stout.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/chionthar-consortium/activity/README.md
+++ b/20-Factions/chionthar-consortium/activity/README.md
@@ -1,0 +1,7 @@
+# Chionthar Consortium — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — secure-exclusive-warehousing-contract.

--- a/20-Factions/chionthar-consortium/activity/week_0/README.md
+++ b/20-Factions/chionthar-consortium/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Chionthar Consortium — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [secure-exclusive-warehousing-contract.md](secure-exclusive-warehousing-contract.md)

--- a/20-Factions/chionthar-consortium/activity/week_0/secure-exclusive-warehousing-contract.md
+++ b/20-Factions/chionthar-consortium/activity/week_0/secure-exclusive-warehousing-contract.md
@@ -1,0 +1,19 @@
+---
+name: secure-exclusive-warehousing-contract
+faction: chionthar-consortium
+week: 0
+discovery_dc: 10
+dc: 10
+success: true
+public: true
+---
+
+# Secure Exclusive Warehousing Contract
+
+The [Sembian Kontor](../../../sembian-kontor/summary.md) gets wind of Master Joric's plan. Bursar [Korgan Ironhand](../../../sembian-kontor/people/korgan-ironhand.md) leverages his vast cash reserves to make a last-minute, unbeatable offer to the warehouse owners. The Chionthar Consortium not only loses the exclusive contract but is forced to pay even higher rates for storage, marking a major financial defeat at the hands of their foreign rival.
+
+## See also
+
+- [Chionthar Consortium](../../summary.md)
+- [Sembian Kontor](../../../sembian-kontor/summary.md)
+- [Master Joric the Stout](../../people/joric-the-stout.md)

--- a/20-Factions/circle-of-the-inner-grove/README.md
+++ b/20-Factions/circle-of-the-inner-grove/README.md
@@ -6,3 +6,4 @@ Druidic sect protecting the Chionthar from the city's pollution and industrial e
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: elder-elion.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/circle-of-the-inner-grove/activity/README.md
+++ b/20-Factions/circle-of-the-inner-grove/activity/README.md
@@ -1,0 +1,7 @@
+# Circle of the Inner Grove — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — perform-a-ritual-of-warding.

--- a/20-Factions/circle-of-the-inner-grove/activity/week_0/README.md
+++ b/20-Factions/circle-of-the-inner-grove/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Circle of the Inner Grove — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [perform-a-ritual-of-warding.md](perform-a-ritual-of-warding.md)

--- a/20-Factions/circle-of-the-inner-grove/activity/week_0/perform-a-ritual-of-warding.md
+++ b/20-Factions/circle-of-the-inner-grove/activity/week_0/perform-a-ritual-of-warding.md
@@ -1,0 +1,19 @@
+---
+name: perform-a-ritual-of-warding
+faction: circle-of-the-inner-grove
+week: 0
+discovery_dc: 20
+dc: 10
+success: true
+public: true
+---
+
+# Perform a Ritual of Warding
+
+The ritual — meant to ward the [Whisperwood Copse](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/README.md) against the [Western Gate's](../../../western-gate-trading-company/summary.md) loggers — is corrupted by the region's lingering infernal energy. Instead of strengthening the natural animals, it twists them into fiendish, aggressive versions that attack loggers and druids alike. [Elder Elion](../../people/elder-elion.md) has inadvertently created a bigger problem, blighting the wood he sought to protect.
+
+## See also
+
+- [Circle of the Inner Grove](../../summary.md)
+- [Western Gate Trading Company](../../../western-gate-trading-company/summary.md) — the loggers it was meant to deter.
+- [Wood of Sharp Teeth (local face)](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/README.md)

--- a/20-Factions/council-of-four/README.md
+++ b/20-Factions/council-of-four/README.md
@@ -5,3 +5,4 @@ Plutocratic executive branch; a boardroom of capitalists led by the Archduke.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/council-of-four/activity/README.md
+++ b/20-Factions/council-of-four/activity/README.md
@@ -1,0 +1,7 @@
+# Council of Four — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — finalize-hinterland-logging-charter.

--- a/20-Factions/council-of-four/activity/week_0/README.md
+++ b/20-Factions/council-of-four/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Council of Four — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [finalize-hinterland-logging-charter.md](finalize-hinterland-logging-charter.md)

--- a/20-Factions/council-of-four/activity/week_0/finalize-hinterland-logging-charter.md
+++ b/20-Factions/council-of-four/activity/week_0/finalize-hinterland-logging-charter.md
@@ -1,0 +1,19 @@
+---
+name: finalize-hinterland-logging-charter
+faction: council-of-four
+week: 0
+discovery_dc: 5
+dc: 5
+success: false
+public: false
+---
+
+# Finalize Hinterland Logging Expansion Charter
+
+[Lord Corin Durinbold](../../../peerage-of-blood/people/corin-durinbold.md), leading the [Peerage of Blood](../../../peerage-of-blood/summary.md), finds a procedural loophole in the city charter regarding land use outside the walls. He successfully tables the motion for "further review," delaying the charter indefinitely and dealing a public blow to Archduke [Lyra Silvershield's](../../../western-gate-trading-company/people/lyra-silvershield.md) authority.
+
+## See also
+
+- [Council of Four](../../summary.md)
+- [Peerage of Blood](../../../peerage-of-blood/summary.md)
+- [Western Gate Trading Company](../../../western-gate-trading-company/summary.md) — Archduke Silvershield's logging program is the prize.

--- a/20-Factions/cult-of-the-returning-lord/README.md
+++ b/20-Factions/cult-of-the-returning-lord/README.md
@@ -6,3 +6,4 @@ Bhaal-worshipping death cult consecrating sewer altars with the blood of 'nobodi
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-bhaal-celebrant.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/cult-of-the-returning-lord/activity/README.md
+++ b/20-Factions/cult-of-the-returning-lord/activity/README.md
@@ -1,0 +1,7 @@
+# Cult of the Returning Lord — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — consecrate-a-sewer-altar.

--- a/20-Factions/cult-of-the-returning-lord/activity/week_0/README.md
+++ b/20-Factions/cult-of-the-returning-lord/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Cult of the Returning Lord — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [consecrate-a-sewer-altar.md](consecrate-a-sewer-altar.md)

--- a/20-Factions/cult-of-the-returning-lord/activity/week_0/consecrate-a-sewer-altar.md
+++ b/20-Factions/cult-of-the-returning-lord/activity/week_0/consecrate-a-sewer-altar.md
@@ -1,0 +1,19 @@
+---
+name: consecrate-a-sewer-altar
+faction: cult-of-the-returning-lord
+week: 0
+discovery_dc: 20
+dc: 10
+success: true
+public: false
+---
+
+# Consecrate a Sewer Altar with a 'Nobody's' Blood
+
+Bhaal cultists kidnap a homeless man from a [Heapside](../../../../30-Places/sword-coast/baldurs-gate/lower-city/heapside.md) alley and murder him on a makeshift altar in the [Undercity](../../../../30-Places/sword-coast/baldurs-gate/undercity/README.md), consecrating the space for future, more important rituals. The body is disposed of and the man is never missed.
+
+## See also
+
+- [Cult of the Returning Lord](../../summary.md)
+- [Heapside](../../../../30-Places/sword-coast/baldurs-gate/lower-city/heapside.md)
+- [Undercity](../../../../30-Places/sword-coast/baldurs-gate/undercity/README.md)

--- a/20-Factions/elturel-remembrance-society/README.md
+++ b/20-Factions/elturel-remembrance-society/README.md
@@ -6,3 +6,4 @@ Elturian-survivor support group radicalized into hunting 'infernal' Baldurian me
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: perrine-hhune.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/elturel-remembrance-society/activity/README.md
+++ b/20-Factions/elturel-remembrance-society/activity/README.md
@@ -1,0 +1,7 @@
+# Elturel Remembrance Society — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — declare-a-baldurian-merchant-infernal.

--- a/20-Factions/elturel-remembrance-society/activity/week_0/README.md
+++ b/20-Factions/elturel-remembrance-society/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Elturel Remembrance Society — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [declare-a-baldurian-merchant-infernal.md](declare-a-baldurian-merchant-infernal.md)

--- a/20-Factions/elturel-remembrance-society/activity/week_0/declare-a-baldurian-merchant-infernal.md
+++ b/20-Factions/elturel-remembrance-society/activity/week_0/declare-a-baldurian-merchant-infernal.md
@@ -1,0 +1,18 @@
+---
+name: declare-a-baldurian-merchant-infernal
+faction: elturel-remembrance-society
+week: 0
+discovery_dc: 10
+dc: 5
+success: true
+public: true
+---
+
+# Declare a Baldurian Merchant 'Infernal'
+
+The protest is a dismal failure. The targeted merchant, a popular figure, is defended by his neighbors. The local [Guild](../../../guild/summary.md) Ward Boss, annoyed by the disruption, sends thugs to disperse the protesters, humiliating the Society and branding them as ineffective zealots.
+
+## See also
+
+- [Elturel Remembrance Society](../../summary.md)
+- [The Guild](../../../guild/summary.md)

--- a/20-Factions/flaming-fist/README.md
+++ b/20-Factions/flaming-fist/README.md
@@ -5,4 +5,5 @@ Diminished and corrupt city military and police force, struggling for relevance.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
-- [people/](people/) — Named figures: valerius-flint.
+- [people/](people/) — Named figures: manip-jerrol, valerius-flint.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/flaming-fist/activity/README.md
+++ b/20-Factions/flaming-fist/activity/README.md
@@ -1,0 +1,7 @@
+# Flaming Fist — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — increased-shakedowns-on-wyrms-crossing.

--- a/20-Factions/flaming-fist/activity/week_0/README.md
+++ b/20-Factions/flaming-fist/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Flaming Fist — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [increased-shakedowns-on-wyrms-crossing.md](increased-shakedowns-on-wyrms-crossing.md)

--- a/20-Factions/flaming-fist/activity/week_0/increased-shakedowns-on-wyrms-crossing.md
+++ b/20-Factions/flaming-fist/activity/week_0/increased-shakedowns-on-wyrms-crossing.md
@@ -1,0 +1,20 @@
+---
+name: increased-shakedowns-on-wyrms-crossing
+faction: flaming-fist
+week: 0
+discovery_dc: 5
+dc: 10
+success: false
+public: false
+---
+
+# Increased Shakedowns on Wyrm's Crossing
+
+The aggressive shakedowns at [Wyrm's Crossing](../../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md) backfire spectacularly. A confrontation with ['Mad' Meggan](../../../free-traders-of-the-outskirts/people/mad-meggan.md) of the [Free Traders](../../../free-traders-of-the-outskirts/summary.md) erupts into a public brawl on the bridge. The Free Traders, united and furious, refuse to pay, creating a massive, multi-day blockade of Wyrm's Crossing. [Marshal Flint's](../../people/valerius-flint.md) revenue grab results in a net loss of trade and a public relations disaster for the Fist.
+
+## See also
+
+- [Flaming Fist](../../summary.md)
+- [Free Traders of the Outskirts](../../../free-traders-of-the-outskirts/summary.md)
+- [Wyrm's Crossing](../../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md)
+- [people/manip-jerrol.md](../../people/manip-jerrol.md) — the officer running the shakedowns.

--- a/20-Factions/flaming-fist/people/README.md
+++ b/20-Factions/flaming-fist/people/README.md
@@ -4,4 +4,5 @@ Named figures.
 
 ## Index
 
+- [manip-jerrol.md](manip-jerrol.md)
 - [valerius-flint.md](valerius-flint.md)

--- a/20-Factions/flaming-fist/people/manip-jerrol.md
+++ b/20-Factions/flaming-fist/people/manip-jerrol.md
@@ -1,0 +1,22 @@
+---
+name: manip-jerrol
+description: Flaming Fist officer running shakedowns at Wyrm's Crossing; the operational face of the Fist's revenue-grab on the Outer City.
+---
+
+# Manip Jerrol
+
+Mid-rank Flaming Fist officer (rank: Manip) operating at [Wyrm's Crossing](../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md). The day-to-day enforcer of the Fist's increasingly aggressive customs and "protection" pressure on traffic over the bridge, under [Marshal Valerius Flint's](valerius-flint.md) authorization.
+
+## Role
+
+Jerrol's beat is the bridge: tolls, customs spot-checks, and the kind of "encouragement" that tips over from policing into shakedown. He has a reputation for bone-breaking that pre-dates the current pressure campaign — his earlier beating of a refusing [Free Trader](../../free-traders-of-the-outskirts/summary.md) merchant is what put him on Mad' Meggan's list of grievances.
+
+## Week 0
+
+His shakedown push backfired publicly. A confrontation with ['Mad' Meggan](../../free-traders-of-the-outskirts/people/mad-meggan.md) erupted into a brawl on the bridge; the Free Traders' multi-day blockade of Wyrm's Crossing followed. The Fist's revenue grab netted a loss of trade and a public-relations beating. See [activity/week_0/increased-shakedowns-on-wyrms-crossing.md](../activity/week_0/increased-shakedowns-on-wyrms-crossing.md).
+
+## See also
+
+- [Flaming Fist](../summary.md)
+- [Wyrm's Crossing](../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md)
+- [Free Traders of the Outskirts](../../free-traders-of-the-outskirts/summary.md)

--- a/20-Factions/followers-of-the-phoenix/README.md
+++ b/20-Factions/followers-of-the-phoenix/README.md
@@ -6,3 +6,4 @@ Karlach-worshipping cult of righteous fury, growing among tieflings and outcasts
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-ember.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/followers-of-the-phoenix/activity/README.md
+++ b/20-Factions/followers-of-the-phoenix/activity/README.md
@@ -1,0 +1,7 @@
+# Followers of the Phoenix — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — hold-a-sermon-in-new-elturel.

--- a/20-Factions/followers-of-the-phoenix/activity/week_0/README.md
+++ b/20-Factions/followers-of-the-phoenix/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Followers of the Phoenix — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [hold-a-sermon-in-new-elturel.md](hold-a-sermon-in-new-elturel.md)

--- a/20-Factions/followers-of-the-phoenix/activity/week_0/hold-a-sermon-in-new-elturel.md
+++ b/20-Factions/followers-of-the-phoenix/activity/week_0/hold-a-sermon-in-new-elturel.md
@@ -1,0 +1,18 @@
+---
+name: hold-a-sermon-in-new-elturel
+faction: followers-of-the-phoenix
+week: 0
+discovery_dc: 5
+dc: 5
+success: true
+public: true
+---
+
+# Hold a Sermon in New Elturel
+
+[The Ember](../../people/the-ember.md), the charismatic leader of the Karlach-worshipping cult, holds their first public sermon in an abandoned square in [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md). A small crowd of downtrodden tieflings and outcasts is drawn to their message of righteous fury.
+
+## See also
+
+- [Followers of the Phoenix](../../summary.md)
+- [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md)

--- a/20-Factions/free-traders-of-the-outskirts/README.md
+++ b/20-Factions/free-traders-of-the-outskirts/README.md
@@ -6,3 +6,4 @@ Independent caravan masters of the Outer City under 'Mad' Meggan; mutual-protect
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: mad-meggan.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/free-traders-of-the-outskirts/activity/README.md
+++ b/20-Factions/free-traders-of-the-outskirts/activity/README.md
@@ -1,0 +1,7 @@
+# Free Traders of the Outskirts — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — establish-a-mutual-protection-pact.

--- a/20-Factions/free-traders-of-the-outskirts/activity/week_0/README.md
+++ b/20-Factions/free-traders-of-the-outskirts/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Free Traders of the Outskirts — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [establish-a-mutual-protection-pact.md](establish-a-mutual-protection-pact.md)

--- a/20-Factions/free-traders-of-the-outskirts/activity/week_0/establish-a-mutual-protection-pact.md
+++ b/20-Factions/free-traders-of-the-outskirts/activity/week_0/establish-a-mutual-protection-pact.md
@@ -1,0 +1,19 @@
+---
+name: establish-a-mutual-protection-pact
+faction: free-traders-of-the-outskirts
+week: 0
+discovery_dc: 5
+dc: 10
+success: true
+public: true
+---
+
+# Establish a Mutual Protection Pact
+
+['Mad' Meggan](../../people/mad-meggan.md) organizes a pact among the independent caravan masters of the [Outer City](../../../../30-Places/sword-coast/baldurs-gate/outer-city/README.md). They agree to travel in larger, combined convoys and share intelligence on the increasingly aggressive [Flaming Fist](../../../flaming-fist/summary.md) patrols at [Wyrm's Crossing](../../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md).
+
+## See also
+
+- [Free Traders of the Outskirts](../../summary.md)
+- [Flaming Fist](../../../flaming-fist/summary.md)
+- [Wyrm's Crossing](../../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md)

--- a/20-Factions/gilded-vein/README.md
+++ b/20-Factions/gilded-vein/README.md
@@ -6,3 +6,4 @@ Cult of economic assassins worshipping 'Axiom,' purifying the economy through ta
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: valerius-thorne.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/gilded-vein/activity/README.md
+++ b/20-Factions/gilded-vein/activity/README.md
@@ -1,0 +1,7 @@
+# The Gilded Vein — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — poison-a-consortiums-carrier-pigeons.

--- a/20-Factions/gilded-vein/activity/week_0/README.md
+++ b/20-Factions/gilded-vein/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Gilded Vein — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [poison-a-consortiums-carrier-pigeons.md](poison-a-consortiums-carrier-pigeons.md)

--- a/20-Factions/gilded-vein/activity/week_0/poison-a-consortiums-carrier-pigeons.md
+++ b/20-Factions/gilded-vein/activity/week_0/poison-a-consortiums-carrier-pigeons.md
@@ -1,0 +1,18 @@
+---
+name: poison-a-consortiums-carrier-pigeons
+faction: gilded-vein
+week: 0
+discovery_dc: 20
+dc: 15
+success: true
+public: true
+---
+
+# Poison a Consortium's Carrier Pigeons
+
+The cultist assigned the task is caught by a stable hand while trying to poison the pigeon feed at a [Western Gate Trading Company](../../../western-gate-trading-company/summary.md) waystation. The cultist escapes but is identified. The Western Gate is now aware that a new, hostile group is targeting them with poison and significantly increases its security. The Gilded Vein has lost the element of surprise.
+
+## See also
+
+- [The Gilded Vein](../../summary.md)
+- [Western Gate Trading Company](../../../western-gate-trading-company/summary.md)

--- a/20-Factions/gravekeepers/README.md
+++ b/20-Factions/gravekeepers/README.md
@@ -6,3 +6,4 @@ Undead-cleansing cult under Hemlock, warding the city's graveyards against psych
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: hemlock.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/gravekeepers/activity/README.md
+++ b/20-Factions/gravekeepers/activity/README.md
@@ -1,0 +1,7 @@
+# The Gravekeepers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — perform-a-cleansing-ritual-in-tumbledown.

--- a/20-Factions/gravekeepers/activity/week_0/README.md
+++ b/20-Factions/gravekeepers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Gravekeepers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [perform-a-cleansing-ritual-in-tumbledown.md](perform-a-cleansing-ritual-in-tumbledown.md)

--- a/20-Factions/gravekeepers/activity/week_0/perform-a-cleansing-ritual-in-tumbledown.md
+++ b/20-Factions/gravekeepers/activity/week_0/perform-a-cleansing-ritual-in-tumbledown.md
@@ -1,0 +1,18 @@
+---
+name: perform-a-cleansing-ritual-in-tumbledown
+faction: gravekeepers
+week: 0
+discovery_dc: 20
+dc: 10
+success: true
+public: true
+---
+
+# Perform a Cleansing Ritual in Tumbledown
+
+The ritual in the [Tumbledown](../../../../30-Places/sword-coast/baldurs-gate/outer-city/tumbledown-and-floodway.md) graveyards is interrupted by a powerful wraith drawn to the spiritual energy. The Gravekeepers are forced to abandon the cleansing to fight it. They destroy the creature, but not before it shatters a key warding stone, leaving the graveyard more vulnerable than before.
+
+## See also
+
+- [The Gravekeepers](../../summary.md)
+- [Tumbledown and Floodway](../../../../30-Places/sword-coast/baldurs-gate/outer-city/tumbledown-and-floodway.md)

--- a/20-Factions/guild/README.md
+++ b/20-Factions/guild/README.md
@@ -6,3 +6,4 @@ Sophisticated criminal syndicate evolved into the de facto government of the com
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: astele-keene.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/guild/activity/README.md
+++ b/20-Factions/guild/activity/README.md
@@ -1,0 +1,7 @@
+# The Guild — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — organize-winter-relief-for-new-elturel.

--- a/20-Factions/guild/activity/week_0/README.md
+++ b/20-Factions/guild/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Guild — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [organize-winter-relief-for-new-elturel.md](organize-winter-relief-for-new-elturel.md)

--- a/20-Factions/guild/activity/week_0/organize-winter-relief-for-new-elturel.md
+++ b/20-Factions/guild/activity/week_0/organize-winter-relief-for-new-elturel.md
@@ -1,0 +1,19 @@
+---
+name: organize-winter-relief-for-new-elturel
+faction: guild
+week: 0
+discovery_dc: 0
+dc: 5
+success: true
+public: false
+---
+
+# Organize Winter Relief for New Elturel
+
+[Nine-Fingers Keene (Astele Keene)](../../people/astele-keene.md) has her Ward Bosses distribute blankets and food stores to the poorest residents of the [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md) refugee camp — a highly public act of charity designed to earn loyalty and show up the city's neglectful government.
+
+## See also
+
+- [The Guild](../../summary.md)
+- [Hellriders of New Elturel](../../../hellriders-of-new-elturel/summary.md) — the same population the Hellriders' petition aimed to serve.
+- [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md)

--- a/20-Factions/hands-of-the-absolute/README.md
+++ b/20-Factions/hands-of-the-absolute/README.md
@@ -6,3 +6,4 @@ Splinter cult listening for the 'Echo' of the Netherbrain in the city's psychic 
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-voice.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/hands-of-the-absolute/activity/README.md
+++ b/20-Factions/hands-of-the-absolute/activity/README.md
@@ -1,0 +1,7 @@
+# Hands of the Absolute — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — listen-for-the-echo.

--- a/20-Factions/hands-of-the-absolute/activity/week_0/README.md
+++ b/20-Factions/hands-of-the-absolute/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Hands of the Absolute — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [listen-for-the-echo.md](listen-for-the-echo.md)

--- a/20-Factions/hands-of-the-absolute/activity/week_0/listen-for-the-echo.md
+++ b/20-Factions/hands-of-the-absolute/activity/week_0/listen-for-the-echo.md
@@ -1,0 +1,17 @@
+---
+name: listen-for-the-echo
+faction: hands-of-the-absolute
+week: 0
+discovery_dc: 20
+dc: 15
+success: true
+public: false
+---
+
+# Listen for the 'Echo'
+
+The ritual is too successful. Instead of a faint echo, the cell contacts a feral psychic entity. The entity lashes out, killing one cultist and driving another mad before vanishing. [The Voice](../../people/the-voice.md) is left with a terrified, diminished flock and the knowledge that something dangerous has answered their prayers.
+
+## See also
+
+- [Hands of the Absolute](../../summary.md)

--- a/20-Factions/harpers/README.md
+++ b/20-Factions/harpers/README.md
@@ -6,3 +6,4 @@ Semi-secret balance-keepers gathering intelligence and subtly intervening agains
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-nightingale.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/harpers/activity/README.md
+++ b/20-Factions/harpers/activity/README.md
@@ -1,0 +1,7 @@
+# The Harpers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — plant-an-agent-in-the-masons-guild.

--- a/20-Factions/harpers/activity/week_0/README.md
+++ b/20-Factions/harpers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Harpers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [plant-an-agent-in-the-masons-guild.md](plant-an-agent-in-the-masons-guild.md)

--- a/20-Factions/harpers/activity/week_0/plant-an-agent-in-the-masons-guild.md
+++ b/20-Factions/harpers/activity/week_0/plant-an-agent-in-the-masons-guild.md
@@ -1,0 +1,18 @@
+---
+name: plant-an-agent-in-the-masons-guild
+faction: harpers
+week: 0
+discovery_dc: 20
+dc: 15
+success: true
+public: true
+---
+
+# Plant an Agent in the Masons' Guild
+
+The Harper agent is vetted, but his cover story has a minor flaw. Suspicious, [Master Borin Stonehand's](../../../wc-masons-sculptors/people/borin-stonehand.md) people put the agent under surveillance. The agent gets the job but is watched at all times and fed misinformation, effectively becoming a double agent without his knowledge. The Harpers' investigation is compromised from the start.
+
+## See also
+
+- [The Harpers](../../summary.md)
+- [Worshipful Company of Masons & Sculptors](../../../wc-masons-sculptors/summary.md)

--- a/20-Factions/hellriders-of-new-elturel/README.md
+++ b/20-Factions/hellriders-of-new-elturel/README.md
@@ -6,3 +6,4 @@ Volunteer militia and informal government of the New Elturel refugee district.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: high-watcher-alena.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/hellriders-of-new-elturel/activity/README.md
+++ b/20-Factions/hellriders-of-new-elturel/activity/README.md
@@ -1,0 +1,7 @@
+# Hellriders of New Elturel — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — submit-petition-for-citizenship.

--- a/20-Factions/hellriders-of-new-elturel/activity/week_0/README.md
+++ b/20-Factions/hellriders-of-new-elturel/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Hellriders of New Elturel — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [submit-petition-for-citizenship.md](submit-petition-for-citizenship.md)

--- a/20-Factions/hellriders-of-new-elturel/activity/week_0/submit-petition-for-citizenship.md
+++ b/20-Factions/hellriders-of-new-elturel/activity/week_0/submit-petition-for-citizenship.md
@@ -1,0 +1,20 @@
+---
+name: submit-petition-for-citizenship
+faction: hellriders-of-new-elturel
+week: 0
+discovery_dc: 0
+dc: 15
+success: true
+public: true
+---
+
+# Submit Petition for Citizenship to the High Hall
+
+The Hellriders' formal petition for citizenship is filed at the High Hall. An aide to a nativist patriar leaks the petition, along with a falsified cost-analysis report, to the [Baldur's Mouth](../../../baldurs-mouth/summary.md). The resulting article stokes public fear about the "refugee burden," turning public opinion against the Hellriders and making citizenship an even more distant goal.
+
+## See also
+
+- [Hellriders of New Elturel](../../summary.md)
+- [Patriar Heritage Society](../../../patriar-heritage-society/summary.md) — likely source of the leak.
+- [Baldur's Mouth](../../../baldurs-mouth/summary.md)
+- [Parliament of Peers](../../../parliament-of-peers/summary.md) — the venue for the parallel Refugee Relief debate.

--- a/20-Factions/high-moon-coster/README.md
+++ b/20-Factions/high-moon-coster/README.md
@@ -7,3 +7,4 @@ Remnant coster led by the Oberon family; bankrolling adventurers in hopes of res
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: oberon-family.
 - [associations/](associations/) — Items, holdings, vehicles (cloakwood-expedition).
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/high-moon-coster/activity/README.md
+++ b/20-Factions/high-moon-coster/activity/README.md
@@ -1,0 +1,7 @@
+# High Moon Coster — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — sponsor-an-adventuring-party.

--- a/20-Factions/high-moon-coster/activity/week_0/README.md
+++ b/20-Factions/high-moon-coster/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# High Moon Coster — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [sponsor-an-adventuring-party.md](sponsor-an-adventuring-party.md)

--- a/20-Factions/high-moon-coster/activity/week_0/sponsor-an-adventuring-party.md
+++ b/20-Factions/high-moon-coster/activity/week_0/sponsor-an-adventuring-party.md
@@ -1,0 +1,20 @@
+---
+name: sponsor-an-adventuring-party
+faction: high-moon-coster
+week: 0
+discovery_dc: 15
+dc: 15
+success: true
+public: true
+---
+
+# Sponsor an Adventuring Party
+
+The High Moon Coster, led by the Oberon family, scrapes together enough coin to sponsor a fledgling adventuring party to explore a rumored ruin in the [Cloakwood](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/cloakwood/README.md), hoping to find a rare artifact that can restore a sliver of their family's lost fortune.
+
+> Source note: this row is labelled "Remnant Costers (Iron Throne" in `faction-quests.xlsx`, but the description names the High Moon Coster as the actor; filed accordingly.
+
+## See also
+
+- [High Moon Coster](../../summary.md)
+- [Cloakwood](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/cloakwood/README.md)

--- a/20-Factions/knights-of-the-shield/README.md
+++ b/20-Factions/knights-of-the-shield/README.md
@@ -7,3 +7,4 @@ Resurgent diabolist secret society recruiting dispossessed patriars in exchange 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-recruiter.
 - [associations/](associations/) — Items, holdings, vehicles (soul-coins, the-infernal-ledger).
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/knights-of-the-shield/activity/README.md
+++ b/20-Factions/knights-of-the-shield/activity/README.md
@@ -1,0 +1,7 @@
+# Knights of the Shield — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — recruit-a-dispossessed-patriar.

--- a/20-Factions/knights-of-the-shield/activity/week_0/README.md
+++ b/20-Factions/knights-of-the-shield/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Knights of the Shield — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [recruit-a-dispossessed-patriar.md](recruit-a-dispossessed-patriar.md)

--- a/20-Factions/knights-of-the-shield/activity/week_0/recruit-a-dispossessed-patriar.md
+++ b/20-Factions/knights-of-the-shield/activity/week_0/recruit-a-dispossessed-patriar.md
@@ -1,0 +1,19 @@
+---
+name: recruit-a-dispossessed-patriar
+faction: knights-of-the-shield
+week: 0
+discovery_dc: 20
+dc: 15
+success: false
+public: false
+---
+
+# Recruit a Dispossessed Patriar
+
+[Lord Hlath](../../../peerage-of-blood/people/lord-hlath.md), though bitter at the [Amnian Kontor's](../../../amnian-kontor/summary.md) foreclosure, is a traditionalist and finds the Knights' diabolical dealings repugnant. He not only refuses their offer but, in a fit of patriotic pique, anonymously tips off a priest at the Watchful Shield Shrine in [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md) about the Knights' resurgence. The recruitment attempt fails and exposes their renewed activity.
+
+## See also
+
+- [Knights of the Shield](../../summary.md)
+- [Peerage of Blood](../../../peerage-of-blood/summary.md)
+- [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md)

--- a/20-Factions/lantaner-concession/README.md
+++ b/20-Factions/lantaner-concession/README.md
@@ -6,3 +6,4 @@ Secretive gnomish enclave with a state-sanctioned monopoly on smokepowder.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: glim-nimblewhiz.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/lantaner-concession/activity/README.md
+++ b/20-Factions/lantaner-concession/activity/README.md
@@ -1,0 +1,7 @@
+# Lantaner Concession — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — root-out-an-industrial-spy.

--- a/20-Factions/lantaner-concession/activity/week_0/README.md
+++ b/20-Factions/lantaner-concession/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Lantaner Concession — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [root-out-an-industrial-spy.md](root-out-an-industrial-spy.md)

--- a/20-Factions/lantaner-concession/activity/week_0/root-out-an-industrial-spy.md
+++ b/20-Factions/lantaner-concession/activity/week_0/root-out-an-industrial-spy.md
@@ -1,0 +1,19 @@
+---
+name: root-out-an-industrial-spy
+faction: lantaner-concession
+week: 0
+discovery_dc: 20
+dc: 10
+success: false
+public: false
+---
+
+# Root Out an Industrial Spy
+
+The apprentice spy, forewarned by an accomplice, manages to escape the [Cogwork Quay](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md) just before security closes in. They make it out of the enclave with a partial schematic of the smokepowder mechanism, delivering a valuable secret to their handlers in the [Worshipful Company of Smiths & Armorers](../../../wc-smiths-armorers/summary.md). The Concession now has a known security breach.
+
+## See also
+
+- [Lantaner Concession](../../summary.md)
+- [Worshipful Company of Smiths & Armorers](../../../wc-smiths-armorers/summary.md)
+- [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md) — the Cogwork Quay sits on the waterfront.

--- a/20-Factions/parliament-of-peers/README.md
+++ b/20-Factions/parliament-of-peers/README.md
@@ -5,3 +5,4 @@ Bicameral legislature comprising the Peerage of Coin and the Peerage of Blood.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/parliament-of-peers/activity/README.md
+++ b/20-Factions/parliament-of-peers/activity/README.md
@@ -1,0 +1,7 @@
+# Parliament of Peers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — debate-the-refugee-relief-act.

--- a/20-Factions/parliament-of-peers/activity/week_0/README.md
+++ b/20-Factions/parliament-of-peers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Parliament of Peers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [debate-the-refugee-relief-act.md](debate-the-refugee-relief-act.md)

--- a/20-Factions/parliament-of-peers/activity/week_0/debate-the-refugee-relief-act.md
+++ b/20-Factions/parliament-of-peers/activity/week_0/debate-the-refugee-relief-act.md
@@ -1,0 +1,20 @@
+---
+name: debate-the-refugee-relief-act
+faction: parliament-of-peers
+week: 0
+discovery_dc: 5
+dc: 10
+success: true
+public: false
+---
+
+# Debate the Refugee Relief Act
+
+The bill is formally shelved after a series of acrimonious debates. The [Peerage of Blood](../../../peerage-of-blood/summary.md), citing fiscal concerns and "civic purity," successfully filibusters the final vote, leaving the refugees with no official aid and increasing tensions in the [Outer City](../../../../30-Places/sword-coast/baldurs-gate/outer-city/README.md).
+
+## See also
+
+- [Parliament of Peers](../../summary.md)
+- [Peerage of Blood](../../../peerage-of-blood/summary.md)
+- [Hellriders of New Elturel](../../../hellriders-of-new-elturel/summary.md) — the refugees the bill was supposed to aid.
+- [Outer City](../../../../30-Places/sword-coast/baldurs-gate/outer-city/README.md)

--- a/20-Factions/party/summary.md
+++ b/20-Factions/party/summary.md
@@ -1,29 +1,41 @@
 ---
 name: party
-description: The player characters — a cell of independent operators caught between every other faction in the city.
+description: The player characters — a small, deniable cell of independent operators with no shared employer and increasingly tangled ties to the city's factions.
 ---
 
 # The Party
 
-The player characters. By the time of the campaign's opening week they are a known, deniable, independent operator group used as a hinge by half the city's factions. This page is a placeholder: fill it from session 0 character creation. Individual PC dossiers go under `people/` once the players have rolled them.
+The four player characters at the table. They began week 0 as strangers thrown together by the city's pull rather than any prior compact: a Sharran monk on a long observation, a fiery Karlach-cultist barbarian, a Great-Old-One warlock chasing a buried secret, and a cynical Lathanderian cleric raising coin for a starving home town. They have no shared faction, no employer of record, and no public name. That deniability is the closest thing the party has to an asset.
 
 ## Ideology
 
-_To be written from session 0._ The party's collective stance — what they will and won't do for coin, who they protect by reflex — is a player decision rather than a setting fact.
+There is no shared creed. Each member's reasons for adventuring point in a different direction — knowledge, money, observation, fury — and the party's working compact is pragmatic: protect each other, take work that pays, do not get cornered by any single faction. The shared instinct is **independence**: refuse to be owned by Kontor, guild, cult, or government.
 
 ## Membership
 
-_To be written from session 0._ Each PC gets a page under `people/<pc-slug>.md` with frontmatter, name heading, role, backstory, and ties to specific factions. Use the existing leader-page format (e.g., `20-Factions/peerage-of-blood/people/corin-durinbold.md`) as the structural template.
+Four PCs. Each gets a page under [`people/`](people/) with the source-specified stats, backstory, and faction ties:
+
+- [Bror "The Shadow Stone"](people/bror.md) — Mountain Dwarf monk, Sharran observer.
+- [Spark](people/spark.md) — Zariel Tiefling barbarian, Followers of the Phoenix.
+- [Elia Thorne](people/elia-thorne.md) — Half-Elf warlock, Great Old One pact.
+- [Kaelan of Beregost](people/kaelan.md) — Human Life Cleric of Lathander, raising coin for his home town.
+
+NPC allies who travel with the party (e.g. Finn of New Elturel, Jaredith Heartsong) are recorded under their faction or location pages, not under `party/people/`.
 
 ## Methods
 
-_To be written from session 0._
+Mixed and improvised: Bror's stealth and observation, Spark's overwhelming violence, Elia's eldritch utility, Kaelan's healing-for-fee. The party leans into work that other factions need done deniably — exactly the kind of work the [Guild](../guild/summary.md), [Harpers](../harpers/summary.md), and [Hellriders](../hellriders-of-new-elturel/summary.md) cannot do under their own banners.
 
 ## Hooks and Relationships
 
-Outbound links left empty for now; the party's ties to other factions are best added as they emerge in play. When in doubt, search `dm-notes.docx` for the relevant PC name and cross-reference against existing faction summaries.
+Inbound ties:
+
+- [Followers of the Phoenix](../followers-of-the-phoenix/summary.md) — Spark's parent cult.
+- [Hellriders of New Elturel](../hellriders-of-new-elturel/summary.md) — Jaredith's prior loyalty; the party intersects with Hellrider business through him.
+- [Sembian Kontor](../sembian-kontor/summary.md), [Western Gate Trading Company](../western-gate-trading-company/summary.md) — both visibly active in the hinterlands the party will work in.
+
+Activity by week is in [`activity/`](activity/).
 
 ## See also
 
-- Session 0 character creation notes.
-- `dm-notes.docx` for in-play references to specific PCs.
+- Source: `raw-ingest/cloaks-and-conspiracies/party.docx`, `player-companion.docx`.

--- a/20-Factions/patriar-heritage-society/README.md
+++ b/20-Factions/patriar-heritage-society/README.md
@@ -6,3 +6,4 @@ Nativist patriar club organizing the Peerage of Blood as a unified voting bloc.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [associations/](associations/) — Items, holdings, vehicles (baldurian-purity-gala, silver-fist-fund).
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/patriar-heritage-society/activity/README.md
+++ b/20-Factions/patriar-heritage-society/activity/README.md
@@ -1,0 +1,7 @@
+# Patriar Heritage Society — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — host-a-baldurian-purity-gala.

--- a/20-Factions/patriar-heritage-society/activity/week_0/README.md
+++ b/20-Factions/patriar-heritage-society/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Patriar Heritage Society — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [host-a-baldurian-purity-gala.md](host-a-baldurian-purity-gala.md)

--- a/20-Factions/patriar-heritage-society/activity/week_0/host-a-baldurian-purity-gala.md
+++ b/20-Factions/patriar-heritage-society/activity/week_0/host-a-baldurian-purity-gala.md
@@ -1,0 +1,19 @@
+---
+name: host-a-baldurian-purity-gala
+faction: patriar-heritage-society
+week: 0
+discovery_dc: 10
+dc: 5
+success: true
+public: false
+---
+
+# Host a 'Baldurian Purity' Gala
+
+[Lord Corin Durinbold](../../../peerage-of-blood/people/corin-durinbold.md) hosts an exclusive gala for members of the [Peerage of Blood](../../../peerage-of-blood/summary.md). The theme is "Baldurian Purity," and the event is a thinly veiled political rally against the influence of the foreign Kontors and "new money" consortiums.
+
+## See also
+
+- [Patriar Heritage Society](../../summary.md)
+- [Peerage of Blood](../../../peerage-of-blood/summary.md)
+- [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md)

--- a/20-Factions/peerage-of-blood/README.md
+++ b/20-Factions/peerage-of-blood/README.md
@@ -5,4 +5,5 @@ Old-money house representing patriar families fighting to preserve traditional r
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
-- [people/](people/) — Named figures: corin-durinbold.
+- [people/](people/) — Named figures: corin-durinbold, lord-hlath.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/peerage-of-blood/activity/README.md
+++ b/20-Factions/peerage-of-blood/activity/README.md
@@ -1,0 +1,7 @@
+# Peerage of Blood — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — block-the-new-kontor-wayleave.

--- a/20-Factions/peerage-of-blood/activity/week_0/README.md
+++ b/20-Factions/peerage-of-blood/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Peerage of Blood — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [block-the-new-kontor-wayleave.md](block-the-new-kontor-wayleave.md)

--- a/20-Factions/peerage-of-blood/activity/week_0/block-the-new-kontor-wayleave.md
+++ b/20-Factions/peerage-of-blood/activity/week_0/block-the-new-kontor-wayleave.md
@@ -1,0 +1,19 @@
+---
+name: block-the-new-kontor-wayleave
+faction: peerage-of-blood
+week: 0
+discovery_dc: 10
+dc: 10
+success: true
+public: true
+---
+
+# Block the 'New Kontor Wayleave' Proposal
+
+Led by [Lord Corin Durinbold](../../people/corin-durinbold.md), the traditionalist patriars successfully block a proposal from the [Amnian Kontor](../../../amnian-kontor/summary.md) that would grant them a private, toll-free wayleave through a section of the Lower City, arguing it's a gross violation of Baldurian sovereignty. The vote is a rare victory for the old guard.
+
+## See also
+
+- [Peerage of Blood](../../summary.md)
+- [Amnian Kontor](../../../amnian-kontor/summary.md)
+- [Patriar Heritage Society](../../../patriar-heritage-society/summary.md) — the gala mobilized the bloc that delivered this win.

--- a/20-Factions/peerage-of-blood/people/README.md
+++ b/20-Factions/peerage-of-blood/people/README.md
@@ -5,3 +5,4 @@ Named figures.
 ## Index
 
 - [corin-durinbold.md](corin-durinbold.md)
+- [lord-hlath.md](lord-hlath.md)

--- a/20-Factions/peerage-of-blood/people/lord-hlath.md
+++ b/20-Factions/peerage-of-blood/people/lord-hlath.md
@@ -1,0 +1,24 @@
+---
+name: lord-hlath
+description: Dispossessed patriar — Amnian foreclosure took his Manorborn estate in week 0; refused the Knights of the Shield's recruitment offer.
+---
+
+# Lord Hlath
+
+A patriar of House Hlath. As of week 0, dispossessed: the [Amnian Kontor](../../../amnian-kontor/summary.md) finalized the foreclosure on his Manorborn estate to settle gambling debts owed to Amnian lenders. The eviction was quiet, ungentle, and complete.
+
+## Role
+
+Hlath is the textbook target the [Knights of the Shield](../../../knights-of-the-shield/summary.md) were created to recruit: a recently-fallen patriar with a grievance and no remaining political leverage. He refused them. A traditionalist — and, despite the bitterness, a Baldurian patriot — he found their diabolical pact terms repugnant and instead tipped off a priest at the Watchful Shield Shrine in [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md) about the Knights' resurgence. The recruitment failed and exposed the Knights' renewed activity.
+
+## Pressure points
+
+- [Lord Corin Durinbold](corin-durinbold.md) tried to publicly sponsor Hlath's family after the foreclosure; Amnian agents intercepted them first and bought (or intimidated) them into refusing the aid, making Durinbold look outmaneuvered.
+- An Amnian-friendly buyer is lined up for the estate; Durinbold has filed an injunction citing an obscure ancient property law to freeze the sale.
+
+## See also
+
+- [Peerage of Blood](../summary.md)
+- [Amnian Kontor](../../amnian-kontor/summary.md)
+- [Knights of the Shield](../../knights-of-the-shield/summary.md)
+- [Manorborn](../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md)

--- a/20-Factions/peerage-of-coin/README.md
+++ b/20-Factions/peerage-of-coin/README.md
@@ -5,3 +5,4 @@ New-money house where corporate entities buy seats and laws are drafted on econo
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/peerage-of-coin/activity/README.md
+++ b/20-Factions/peerage-of-coin/activity/README.md
@@ -1,0 +1,7 @@
+# Peerage of Coin — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — push-through-the-harbor-dredging-levy.

--- a/20-Factions/peerage-of-coin/activity/week_0/README.md
+++ b/20-Factions/peerage-of-coin/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Peerage of Coin — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [push-through-the-harbor-dredging-levy.md](push-through-the-harbor-dredging-levy.md)

--- a/20-Factions/peerage-of-coin/activity/week_0/push-through-the-harbor-dredging-levy.md
+++ b/20-Factions/peerage-of-coin/activity/week_0/push-through-the-harbor-dredging-levy.md
@@ -1,0 +1,21 @@
+---
+name: push-through-the-harbor-dredging-levy
+faction: peerage-of-coin
+week: 0
+discovery_dc: 5
+dc: 5
+success: true
+public: false
+---
+
+# Push Through the 'Harbor Dredging Levy'
+
+The major shipping factions, led by the [Chionthar Consortium](../../../chionthar-consortium/summary.md) and the [Sembian Kontor](../../../sembian-kontor/summary.md), successfully lobby to pass a new levy on all non-guild vessels entering [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md), framing it as necessary to fund the dredging of the Chionthar. The cost is passed on to independent merchants.
+
+## See also
+
+- [Peerage of Coin](../../summary.md)
+- [Chionthar Consortium](../../../chionthar-consortium/summary.md)
+- [Sembian Kontor](../../../sembian-kontor/summary.md)
+- [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md)
+- [Free Traders of the Outskirts](../../../free-traders-of-the-outskirts/summary.md) — the independents the levy hits.

--- a/20-Factions/plague-of-remembrance/README.md
+++ b/20-Factions/plague-of-remembrance/README.md
@@ -6,3 +6,4 @@ Xenophobic death cult of Baldurian purists framing Elturian refugees to start a 
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: emmeline-vhage.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/plague-of-remembrance/activity/README.md
+++ b/20-Factions/plague-of-remembrance/activity/README.md
@@ -1,0 +1,7 @@
+# The Plague of Remembrance — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — start-a-whispering-campaign.

--- a/20-Factions/plague-of-remembrance/activity/week_0/README.md
+++ b/20-Factions/plague-of-remembrance/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Plague of Remembrance — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [start-a-whispering-campaign.md](start-a-whispering-campaign.md)

--- a/20-Factions/plague-of-remembrance/activity/week_0/start-a-whispering-campaign.md
+++ b/20-Factions/plague-of-remembrance/activity/week_0/start-a-whispering-campaign.md
@@ -1,0 +1,19 @@
+---
+name: start-a-whispering-campaign
+faction: plague-of-remembrance
+week: 0
+discovery_dc: 15
+dc: 5
+success: true
+public: false
+---
+
+# Start a Whispering Campaign
+
+[Lady Emmeline Vhage](../../people/emmeline-vhage.md) uses her social connections to start rumors about rising crime and disease being brought in by the Elturian refugees, poisoning public opinion against them in the taverns and salons of the Lower and Upper Cities.
+
+## See also
+
+- [The Plague of Remembrance](../../summary.md)
+- [Patriar Heritage Society](../../../patriar-heritage-society/summary.md) — overlap with the upper-city salon network.
+- [Hellriders of New Elturel](../../../hellriders-of-new-elturel/summary.md) — refugees the rumours target.

--- a/20-Factions/purified/README.md
+++ b/20-Factions/purified/README.md
@@ -6,3 +6,4 @@ Paranoid cell convinced Lantaner gnomes are pacifying the city through clockwork
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: glim-glim.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/purified/activity/README.md
+++ b/20-Factions/purified/activity/README.md
@@ -1,0 +1,7 @@
+# The Purified — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — attempt-to-sabotage-a-water-pump.

--- a/20-Factions/purified/activity/week_0/README.md
+++ b/20-Factions/purified/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Purified — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [attempt-to-sabotage-a-water-pump.md](attempt-to-sabotage-a-water-pump.md)

--- a/20-Factions/purified/activity/week_0/attempt-to-sabotage-a-water-pump.md
+++ b/20-Factions/purified/activity/week_0/attempt-to-sabotage-a-water-pump.md
@@ -1,0 +1,19 @@
+---
+name: attempt-to-sabotage-a-water-pump
+faction: purified
+week: 0
+discovery_dc: 15
+dc: 10
+success: true
+public: false
+---
+
+# Attempt to Sabotage a Water Pump
+
+The clumsy sabotage attempt attracts the attention of a Guild Warden from the [Worshipful Company of Masons & Sculptors](../../../wc-masons-sculptors/summary.md). Investigating the broken pump, the Warden finds strange, non-functional gadgets left behind. The attempt fails to destroy the pump, and now a hostile guild is investigating the cell's activities.
+
+## See also
+
+- [The Purified](../../summary.md)
+- [Worshipful Company of Masons & Sculptors](../../../wc-masons-sculptors/summary.md)
+- [Lantaner Concession](../../../lantaner-concession/summary.md) — the imagined "clockwork pacification" remains the cell's obsession.

--- a/20-Factions/river-rats/README.md
+++ b/20-Factions/river-rats/README.md
@@ -6,3 +6,4 @@ Sewer-and-river smuggling crew operating beneath the Brampton district under Sil
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: silas-the-eel.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/river-rats/activity/README.md
+++ b/20-Factions/river-rats/activity/README.md
@@ -1,0 +1,7 @@
+# River-Rats — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — establish-a-new-sewer-cache.

--- a/20-Factions/river-rats/activity/week_0/README.md
+++ b/20-Factions/river-rats/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# River-Rats — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [establish-a-new-sewer-cache.md](establish-a-new-sewer-cache.md)

--- a/20-Factions/river-rats/activity/week_0/establish-a-new-sewer-cache.md
+++ b/20-Factions/river-rats/activity/week_0/establish-a-new-sewer-cache.md
@@ -1,0 +1,19 @@
+---
+name: establish-a-new-sewer-cache
+faction: river-rats
+week: 0
+discovery_dc: 20
+dc: 10
+success: false
+public: false
+---
+
+# Establish a New Sewer Cache
+
+[Silas the Eel's](../../people/silas-the-eel.md) crew identifies and secures a new, defensible sewer nexus beneath the [Brampton](../../../../30-Places/sword-coast/baldurs-gate/lower-city/brampton.md) district to serve as a hidden cache for smuggled goods, bypassing the increased [Flaming Fist](../../../flaming-fist/summary.md) patrols on [Wyrm's Crossing](../../../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md).
+
+## See also
+
+- [River-Rats](../../summary.md)
+- [Flaming Fist](../../../flaming-fist/summary.md)
+- [Brampton](../../../../30-Places/sword-coast/baldurs-gate/lower-city/brampton.md)

--- a/20-Factions/sembian-kontor/README.md
+++ b/20-Factions/sembian-kontor/README.md
@@ -6,3 +6,4 @@ Ruthlessly utilitarian Sembian trading house brokering bulk goods and mercenary 
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: korgan-ironhand.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/sembian-kontor/activity/README.md
+++ b/20-Factions/sembian-kontor/activity/README.md
@@ -1,0 +1,7 @@
+# Sembian Kontor — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — broker-a-mercenary-contract.

--- a/20-Factions/sembian-kontor/activity/week_0/README.md
+++ b/20-Factions/sembian-kontor/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Sembian Kontor — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [broker-a-mercenary-contract.md](broker-a-mercenary-contract.md)

--- a/20-Factions/sembian-kontor/activity/week_0/broker-a-mercenary-contract.md
+++ b/20-Factions/sembian-kontor/activity/week_0/broker-a-mercenary-contract.md
@@ -1,0 +1,20 @@
+---
+name: broker-a-mercenary-contract
+faction: sembian-kontor
+week: 0
+discovery_dc: 5
+dc: 5
+success: true
+public: true
+---
+
+# Broker a Mercenary Contract for the Western Gate Trading Company
+
+Bursar [Korgan Ironhand](../../people/korgan-ironhand.md) brokers a deal between the [Western Gate Trading Company](../../../western-gate-trading-company/summary.md) and a tough mercenary band. The mercs are hired to "protect" the Company's new logging operations from "bandits" — a clear euphemism for the [Circle of the Inner Grove](../../../circle-of-the-inner-grove/summary.md).
+
+## See also
+
+- [Sembian Kontor](../../summary.md)
+- [Western Gate Trading Company](../../../western-gate-trading-company/summary.md)
+- [Circle of the Inner Grove](../../../circle-of-the-inner-grove/summary.md)
+- The week 1 follow-up will fold "Sembian Mercenaries" rows into the Western Gate's activity per #24.

--- a/20-Factions/silent-shroud/README.md
+++ b/20-Factions/silent-shroud/README.md
@@ -6,3 +6,4 @@ Sharran cult seeking the lost sanctums of the Lady of Loss beneath the city.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: mother-nocturne.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/silent-shroud/activity/README.md
+++ b/20-Factions/silent-shroud/activity/README.md
@@ -1,0 +1,7 @@
+# The Silent Shroud — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — infiltrate-the-house-of-grief.

--- a/20-Factions/silent-shroud/activity/week_0/README.md
+++ b/20-Factions/silent-shroud/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Silent Shroud — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [infiltrate-the-house-of-grief.md](infiltrate-the-house-of-grief.md)

--- a/20-Factions/silent-shroud/activity/week_0/infiltrate-the-house-of-grief.md
+++ b/20-Factions/silent-shroud/activity/week_0/infiltrate-the-house-of-grief.md
@@ -1,0 +1,17 @@
+---
+name: infiltrate-the-house-of-grief
+faction: silent-shroud
+week: 0
+discovery_dc: 20
+dc: 15
+success: false
+public: false
+---
+
+# Infiltrate the House of Grief
+
+The agent's cover is too good. The sanatorium's head cleric takes a special interest in the "grieving noble," subjecting the agent to constant, heartfelt counseling and magical monitoring. This makes any attempt to scout for hidden sanctums impossible without being discovered. The mission is a failure, and the agent is stuck in therapy.
+
+## See also
+
+- [The Silent Shroud](../../summary.md)

--- a/20-Factions/society-of-baldurian-integrity/README.md
+++ b/20-Factions/society-of-baldurian-integrity/README.md
@@ -6,3 +6,4 @@ Cultural-purity zealots warring against 'memetic contamination' from foreign art
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: calliope.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/society-of-baldurian-integrity/activity/README.md
+++ b/20-Factions/society-of-baldurian-integrity/activity/README.md
@@ -1,0 +1,7 @@
+# Society of Baldurian Integrity — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — heckle-a-waterdhavian-bard.

--- a/20-Factions/society-of-baldurian-integrity/activity/week_0/README.md
+++ b/20-Factions/society-of-baldurian-integrity/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Society of Baldurian Integrity — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [heckle-a-waterdhavian-bard.md](heckle-a-waterdhavian-bard.md)

--- a/20-Factions/society-of-baldurian-integrity/activity/week_0/heckle-a-waterdhavian-bard.md
+++ b/20-Factions/society-of-baldurian-integrity/activity/week_0/heckle-a-waterdhavian-bard.md
@@ -1,0 +1,18 @@
+---
+name: heckle-a-waterdhavian-bard
+faction: society-of-baldurian-integrity
+week: 0
+discovery_dc: 5
+dc: 5
+success: false
+public: false
+---
+
+# Heckle a Waterdhavian Bard
+
+[Calliope](../../people/calliope.md) and her followers publicly heckle and shame a visiting bard from Waterdeep who is performing at the Singing Lute, accusing her of singing "memetic poison" and eroding "true" Baldurian culture.
+
+## See also
+
+- [Society of Baldurian Integrity](../../summary.md)
+- [Watch](../../../watch/summary.md) — the same group's Jannath Estate vandalism is opened as a Watch case this week.

--- a/20-Factions/takers-of-the-tithe/README.md
+++ b/20-Factions/takers-of-the-tithe/README.md
@@ -6,3 +6,4 @@ Reaper-cult assassins claiming master artisans as a 'tithe' to their patron.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: the-collector.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/takers-of-the-tithe/activity/README.md
+++ b/20-Factions/takers-of-the-tithe/activity/README.md
@@ -1,0 +1,7 @@
+# The Takers of the Tithe — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — identify-a-master-artisan-as-a-target.

--- a/20-Factions/takers-of-the-tithe/activity/week_0/README.md
+++ b/20-Factions/takers-of-the-tithe/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Takers of the Tithe — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [identify-a-master-artisan-as-a-target.md](identify-a-master-artisan-as-a-target.md)

--- a/20-Factions/takers-of-the-tithe/activity/week_0/identify-a-master-artisan-as-a-target.md
+++ b/20-Factions/takers-of-the-tithe/activity/week_0/identify-a-master-artisan-as-a-target.md
@@ -1,0 +1,18 @@
+---
+name: identify-a-master-artisan-as-a-target
+faction: takers-of-the-tithe
+week: 0
+discovery_dc: 20
+dc: 20
+success: false
+public: false
+---
+
+# Identify a Master Artisan as a Target
+
+The Spotter fails to account for the [Worshipful Company of Goldsmiths & Jewelers](../../../wc-goldsmiths-jewelers/summary.md)' extreme security. The target's movements are erratic and she is always protected by bodyguards. The Takers' surveillance is detected, and the target is placed under high security, forcing the cell to abandon their hunt.
+
+## See also
+
+- [The Takers of the Tithe](../../summary.md)
+- [Worshipful Company of Goldsmiths & Jewelers](../../../wc-goldsmiths-jewelers/summary.md)

--- a/20-Factions/unchained/README.md
+++ b/20-Factions/unchained/README.md
@@ -6,3 +6,4 @@ Githyanki exiles loyal to Prince Orpheus, training in the Outer City for war aga
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: k-laar.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/unchained/activity/README.md
+++ b/20-Factions/unchained/activity/README.md
@@ -1,0 +1,7 @@
+# The Unchained — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — decline-a-mercenary-contract.

--- a/20-Factions/unchained/activity/week_0/README.md
+++ b/20-Factions/unchained/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Unchained — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [decline-a-mercenary-contract.md](decline-a-mercenary-contract.md)

--- a/20-Factions/unchained/activity/week_0/decline-a-mercenary-contract.md
+++ b/20-Factions/unchained/activity/week_0/decline-a-mercenary-contract.md
@@ -1,0 +1,18 @@
+---
+name: decline-a-mercenary-contract
+faction: unchained
+week: 0
+discovery_dc: 15
+dc: 5
+success: true
+public: false
+---
+
+# Decline a Mercenary Contract
+
+[Commander K'laar](../../people/k-laar.md) is approached by an agent of the [Amnian Kontor](../../../amnian-kontor/summary.md) with a lucrative contract to act as private muscle. She refuses, stating the work is without honor and that her warriors are not for rent to settle banking disputes.
+
+## See also
+
+- [The Unchained](../../summary.md)
+- [Amnian Kontor](../../../amnian-kontor/summary.md)

--- a/20-Factions/unveiled/README.md
+++ b/20-Factions/unveiled/README.md
@@ -7,4 +7,4 @@ Conspiracy-paladin cell convinced the Absolute Crisis was a doppelganger false-f
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: xylia.
 - [associations/](associations/) — Items, holdings, vehicles (empty).
-- [activity/](activity/) — Ongoing actions by week (empty).
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/unveiled/activity/README.md
+++ b/20-Factions/unveiled/activity/README.md
@@ -4,3 +4,4 @@ Ongoing actions, organized by in-game week.
 
 ## Index
 
+- [week_0/](week_0/) — reveal-a-conspiracy-via-altered-broadsides.

--- a/20-Factions/unveiled/activity/week_0/README.md
+++ b/20-Factions/unveiled/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Unveiled — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [reveal-a-conspiracy-via-altered-broadsides.md](reveal-a-conspiracy-via-altered-broadsides.md)

--- a/20-Factions/unveiled/activity/week_0/reveal-a-conspiracy-via-altered-broadsides.md
+++ b/20-Factions/unveiled/activity/week_0/reveal-a-conspiracy-via-altered-broadsides.md
@@ -1,0 +1,18 @@
+---
+name: reveal-a-conspiracy-via-altered-broadsides
+faction: unveiled
+week: 0
+discovery_dc: 15
+dc: 10
+success: false
+public: false
+---
+
+# 'Reveal' a Conspiracy via Altered Broadsides
+
+The conspiracists successfully alter the [Baldur's Mouth](../../../baldurs-mouth/summary.md) plates, but their coded messages are so esoteric that the public dismisses them as the ramblings of a madman. The altered broadside becomes a local joke, damaging the group's credibility.
+
+## See also
+
+- [The Unveiled](../../summary.md)
+- [Baldur's Mouth](../../../baldurs-mouth/summary.md)

--- a/20-Factions/watch/README.md
+++ b/20-Factions/watch/README.md
@@ -5,3 +5,4 @@ Patriar-funded watch policing the Upper City; chronically stretched thin.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/watch/activity/README.md
+++ b/20-Factions/watch/activity/README.md
@@ -1,0 +1,7 @@
+# The Watch — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — investigate-vandalism-at-the-jannath-estate.

--- a/20-Factions/watch/activity/week_0/README.md
+++ b/20-Factions/watch/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# The Watch — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [investigate-vandalism-at-the-jannath-estate.md](investigate-vandalism-at-the-jannath-estate.md)

--- a/20-Factions/watch/activity/week_0/investigate-vandalism-at-the-jannath-estate.md
+++ b/20-Factions/watch/activity/week_0/investigate-vandalism-at-the-jannath-estate.md
@@ -1,0 +1,20 @@
+---
+name: investigate-vandalism-at-the-jannath-estate
+faction: watch
+week: 0
+discovery_dc: 10
+dc: 5
+success: false
+public: false
+---
+
+# Investigate Vandalism at the Jannath Estate
+
+The Upper City's Watch investigates a minor incident where red paint was splashed on the "foreign-style" Sembian statues in the Jannath Estate's garden in [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md). The Watch dismisses it as youthful hijinks, unaware it was a statement by the [Society of Baldurian Integrity](../../../society-of-baldurian-integrity/summary.md).
+
+## See also
+
+- [The Watch](../../summary.md)
+- [Society of Baldurian Integrity](../../../society-of-baldurian-integrity/summary.md)
+- [Sembian Kontor](../../../sembian-kontor/summary.md)
+- [Manorborn](../../../../30-Places/sword-coast/baldurs-gate/upper-city/manorborn.md)

--- a/20-Factions/waterdhavian-kontor/README.md
+++ b/20-Factions/waterdhavian-kontor/README.md
@@ -6,3 +6,4 @@ Lords' Alliance embassy controlling trade in northern goods and magical items; e
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: elara-mornwood.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/waterdhavian-kontor/activity/README.md
+++ b/20-Factions/waterdhavian-kontor/activity/README.md
@@ -1,0 +1,7 @@
+# Waterdhavian Kontor — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — acquire-lost-elturian-tomes.

--- a/20-Factions/waterdhavian-kontor/activity/week_0/README.md
+++ b/20-Factions/waterdhavian-kontor/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Waterdhavian Kontor — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [acquire-lost-elturian-tomes.md](acquire-lost-elturian-tomes.md)

--- a/20-Factions/waterdhavian-kontor/activity/week_0/acquire-lost-elturian-tomes.md
+++ b/20-Factions/waterdhavian-kontor/activity/week_0/acquire-lost-elturian-tomes.md
@@ -1,0 +1,19 @@
+---
+name: acquire-lost-elturian-tomes
+faction: waterdhavian-kontor
+week: 0
+discovery_dc: 15
+dc: 5
+success: false
+public: false
+---
+
+# Acquire 'Lost' Elturian Tomes
+
+[Factor Elara Mornwood](../../people/elara-mornwood.md) uses her agents to "acquire" a set of rare historical texts, supposedly lost during the fall of Elturel, from a struggling refugee scholar in [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md) for a pittance. The books are added to the Splendid Yard's library, a source of bitterness for Elturian traditionalists.
+
+## See also
+
+- [Waterdhavian Kontor](../../summary.md)
+- [Hellriders of New Elturel](../../../hellriders-of-new-elturel/summary.md) — the refugees most likely to take the loss as another humiliation.
+- [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md)

--- a/20-Factions/wc-alchemists-apothecaries/README.md
+++ b/20-Factions/wc-alchemists-apothecaries/README.md
@@ -6,3 +6,4 @@ Secretive guild controlling potions, antitoxins, and other exotic substances.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: phineas-droog.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-alchemists-apothecaries/activity/README.md
+++ b/20-Factions/wc-alchemists-apothecaries/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Alchemists & Apothecaries — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — fix-antitoxin-prices.

--- a/20-Factions/wc-alchemists-apothecaries/activity/week_0/README.md
+++ b/20-Factions/wc-alchemists-apothecaries/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Alchemists & Apothecaries — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [fix-antitoxin-prices.md](fix-antitoxin-prices.md)

--- a/20-Factions/wc-alchemists-apothecaries/activity/week_0/fix-antitoxin-prices.md
+++ b/20-Factions/wc-alchemists-apothecaries/activity/week_0/fix-antitoxin-prices.md
@@ -1,0 +1,18 @@
+---
+name: fix-antitoxin-prices
+faction: wc-alchemists-apothecaries
+week: 0
+discovery_dc: 5
+dc: 5
+success: false
+public: false
+---
+
+# Fix Antitoxin Prices
+
+Following a minor outbreak of Sewer Plague in the Lower City, the Company's Court of Assistants votes to triple the price of antitoxin, citing "scarcity of rare reagents." The move is pure price-gouging.
+
+## See also
+
+- [Worshipful Company of Alchemists & Apothecaries](../../summary.md)
+- [The Guild](../../../guild/summary.md) — the antitoxin market squeezes Lower City wards Keene tries to placate.

--- a/20-Factions/wc-butchers-tanners/README.md
+++ b/20-Factions/wc-butchers-tanners/README.md
@@ -6,3 +6,4 @@ Wealthy but socially disdained guild controlling food and leather production.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: borlu.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-butchers-tanners/activity/README.md
+++ b/20-Factions/wc-butchers-tanners/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Butchers & Tanners — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — dump-waste-into-the-chionthar.

--- a/20-Factions/wc-butchers-tanners/activity/week_0/README.md
+++ b/20-Factions/wc-butchers-tanners/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Butchers & Tanners — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [dump-waste-into-the-chionthar.md](dump-waste-into-the-chionthar.md)

--- a/20-Factions/wc-butchers-tanners/activity/week_0/dump-waste-into-the-chionthar.md
+++ b/20-Factions/wc-butchers-tanners/activity/week_0/dump-waste-into-the-chionthar.md
@@ -1,0 +1,19 @@
+---
+name: dump-waste-into-the-chionthar
+faction: wc-butchers-tanners
+week: 0
+discovery_dc: 15
+dc: 5
+success: true
+public: true
+---
+
+# Dump Waste into the Chionthar
+
+Under the cover of darkness, [Goodman Borlu's](../../people/borlu.md) tanneries dump several vats of toxic chemical runoff directly into a tributary of the [Chionthar](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/river-chionthar-lower/README.md), poisoning the water for miles downstream to avoid the cost of proper disposal.
+
+## See also
+
+- [Worshipful Company of Butchers & Tanners](../../summary.md)
+- [Circle of the Inner Grove](../../../circle-of-the-inner-grove/summary.md) — the Circle's mandate is exactly this kind of pollution.
+- [River Chionthar (lower)](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/river-chionthar-lower/README.md)

--- a/20-Factions/wc-cartographers-surveyors/README.md
+++ b/20-Factions/wc-cartographers-surveyors/README.md
@@ -6,3 +6,4 @@ Essential guild whose seal is required on every land deed; closely guarded sewer
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: elias-vancroft.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-cartographers-surveyors/activity/README.md
+++ b/20-Factions/wc-cartographers-surveyors/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Cartographers & Surveyors — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — sell-exclusive-trade-route-maps.

--- a/20-Factions/wc-cartographers-surveyors/activity/week_0/README.md
+++ b/20-Factions/wc-cartographers-surveyors/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Cartographers & Surveyors — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [sell-exclusive-trade-route-maps.md](sell-exclusive-trade-route-maps.md)

--- a/20-Factions/wc-cartographers-surveyors/activity/week_0/sell-exclusive-trade-route-maps.md
+++ b/20-Factions/wc-cartographers-surveyors/activity/week_0/sell-exclusive-trade-route-maps.md
@@ -1,0 +1,17 @@
+---
+name: sell-exclusive-trade-route-maps
+faction: wc-cartographers-surveyors
+week: 0
+discovery_dc: 10
+dc: 5
+success: false
+public: false
+---
+
+# Sell 'Exclusive' Trade Route Maps
+
+[Master Elias Vancroft's](../../people/elias-vancroft.md) guild sells a "newly discovered, safe passage" map through the Trollclaws to two competing caravan masters, pocketing fees from both. The route is, in fact, notoriously dangerous.
+
+## See also
+
+- [Worshipful Company of Cartographers & Surveyors](../../summary.md)

--- a/20-Factions/wc-chandlers-lamplighters/README.md
+++ b/20-Factions/wc-chandlers-lamplighters/README.md
@@ -6,3 +6,4 @@ Provides oil, candles, and torches; lamplighter crews know the city's nightly rh
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: anya-brightwood.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-chandlers-lamplighters/activity/README.md
+++ b/20-Factions/wc-chandlers-lamplighters/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Chandlers & Lamplighters — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — secure-the-city-lamplighting-contract.

--- a/20-Factions/wc-chandlers-lamplighters/activity/week_0/README.md
+++ b/20-Factions/wc-chandlers-lamplighters/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Chandlers & Lamplighters — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [secure-the-city-lamplighting-contract.md](secure-the-city-lamplighting-contract.md)

--- a/20-Factions/wc-chandlers-lamplighters/activity/week_0/secure-the-city-lamplighting-contract.md
+++ b/20-Factions/wc-chandlers-lamplighters/activity/week_0/secure-the-city-lamplighting-contract.md
@@ -1,0 +1,18 @@
+---
+name: secure-the-city-lamplighting-contract
+faction: wc-chandlers-lamplighters
+week: 0
+discovery_dc: 5
+dc: 5
+success: false
+public: false
+---
+
+# Secure the City Lamplighting Contract
+
+[Mistress Anya Brightwood's](../../people/anya-brightwood.md) guild successfully renews its lucrative contract with the [Council of Four](../../../council-of-four/summary.md) to maintain and light the lamps of the Lower and Upper Cities for the next five years, ensuring their steady profit and civic importance.
+
+## See also
+
+- [Worshipful Company of Chandlers & Lamplighters](../../summary.md)
+- [Council of Four](../../../council-of-four/summary.md)

--- a/20-Factions/wc-fishmongers/README.md
+++ b/20-Factions/wc-fishmongers/README.md
@@ -6,3 +6,4 @@ Ancient guild controlling Gray Harbour fishing fleets; food supply leverage.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: marga-saltwind.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-fishmongers/activity/README.md
+++ b/20-Factions/wc-fishmongers/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Fishmongers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — organize-a-dockworker-strike.

--- a/20-Factions/wc-fishmongers/activity/week_0/README.md
+++ b/20-Factions/wc-fishmongers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Fishmongers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [organize-a-dockworker-strike.md](organize-a-dockworker-strike.md)

--- a/20-Factions/wc-fishmongers/activity/week_0/organize-a-dockworker-strike.md
+++ b/20-Factions/wc-fishmongers/activity/week_0/organize-a-dockworker-strike.md
@@ -1,0 +1,21 @@
+---
+name: organize-a-dockworker-strike
+faction: wc-fishmongers
+week: 0
+discovery_dc: 5
+dc: 10
+success: false
+public: false
+---
+
+# Organize a Dockworker Strike
+
+The [Chionthar Consortium](../../../chionthar-consortium/summary.md), anticipating the strike, preemptively hires non-union labor from the desperate refugee population in [New Elturel](../../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md). When the [Wharf Rats](../../../wharf-rats/summary.md) walk out, the strikebreakers move in, protected by Consortium guards. The strike collapses within hours, weakening the Fishmongers' influence and creating bitter resentment between Baldurian dockworkers and Elturian refugees.
+
+## See also
+
+- [Worshipful Company of Fishmongers](../../summary.md)
+- [Chionthar Consortium](../../../chionthar-consortium/summary.md)
+- [Wharf Rats](../../../wharf-rats/summary.md) — the dockworkers' union arm.
+- [Hellriders of New Elturel](../../../hellriders-of-new-elturel/summary.md) — the refugee community the strikebreakers came from.
+- [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md)

--- a/20-Factions/wc-goldsmiths-jewelers/README.md
+++ b/20-Factions/wc-goldsmiths-jewelers/README.md
@@ -6,3 +6,4 @@ Regulators of precious metals and gems; the city's unofficial mint and assay off
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: theronius-goldhand.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-goldsmiths-jewelers/activity/README.md
+++ b/20-Factions/wc-goldsmiths-jewelers/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Goldsmiths & Jewelers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — expose-a-counterfeit-operation.

--- a/20-Factions/wc-goldsmiths-jewelers/activity/week_0/README.md
+++ b/20-Factions/wc-goldsmiths-jewelers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Goldsmiths & Jewelers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [expose-a-counterfeit-operation.md](expose-a-counterfeit-operation.md)

--- a/20-Factions/wc-goldsmiths-jewelers/activity/week_0/expose-a-counterfeit-operation.md
+++ b/20-Factions/wc-goldsmiths-jewelers/activity/week_0/expose-a-counterfeit-operation.md
@@ -1,0 +1,19 @@
+---
+name: expose-a-counterfeit-operation
+faction: wc-goldsmiths-jewelers
+week: 0
+discovery_dc: 15
+dc: 10
+success: false
+public: false
+---
+
+# Expose a Counterfeit Operation
+
+[Master Theronius Goldhand's](../../people/theronius-goldhand.md) agents work with [The Guild](../../../guild/summary.md) to quietly identify and shut down a small-time counterfeiter operating out of [the Undercellar](../../../../30-Places/sword-coast/baldurs-gate/undercity/the-undercellar.md). The Guild gets the counterfeiter, and the Goldsmiths protect the integrity of their trade.
+
+## See also
+
+- [Worshipful Company of Goldsmiths & Jewelers](../../summary.md)
+- [The Guild](../../../guild/summary.md)
+- [The Undercellar](../../../../30-Places/sword-coast/baldurs-gate/undercity/the-undercellar.md)

--- a/20-Factions/wc-masons-sculptors/README.md
+++ b/20-Factions/wc-masons-sculptors/README.md
@@ -6,3 +6,4 @@ Wealthy guild that rebuilt Baldur's Gate post-crisis; near-monopoly on construct
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: borin-stonehand.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-masons-sculptors/activity/README.md
+++ b/20-Factions/wc-masons-sculptors/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Masons & Sculptors — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — cover-up-a-structural-flaw.

--- a/20-Factions/wc-masons-sculptors/activity/week_0/README.md
+++ b/20-Factions/wc-masons-sculptors/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Masons & Sculptors — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [cover-up-a-structural-flaw.md](cover-up-a-structural-flaw.md)

--- a/20-Factions/wc-masons-sculptors/activity/week_0/cover-up-a-structural-flaw.md
+++ b/20-Factions/wc-masons-sculptors/activity/week_0/cover-up-a-structural-flaw.md
@@ -1,0 +1,19 @@
+---
+name: cover-up-a-structural-flaw
+faction: wc-masons-sculptors
+week: 0
+discovery_dc: 15
+dc: 10
+success: false
+public: false
+---
+
+# Cover Up a Structural Flaw
+
+A newly built wall section near the Basilisk Gate shows signs of cracking due to shoddy, cost-cutting work. [Master Borin Stonehand's](../../people/borin-stonehand.md) inner circle pays off the [Flaming Fist](../../../flaming-fist/summary.md) inspector and has a crew perform a hasty, cosmetic repair job in the dead of night to hide the flaw.
+
+## See also
+
+- [Worshipful Company of Masons & Sculptors](../../summary.md)
+- [Flaming Fist](../../../flaming-fist/summary.md)
+- [Harpers](../../../harpers/summary.md) — they planted an agent here this week and are now reading the guild's misinformation.

--- a/20-Factions/wc-mercers-clothiers/README.md
+++ b/20-Factions/wc-mercers-clothiers/README.md
@@ -6,3 +6,4 @@ Arbiters of fashion and status; fine clothing for the city's elite.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: elethra-vance.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-mercers-clothiers/activity/README.md
+++ b/20-Factions/wc-mercers-clothiers/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Mercers & Clothiers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — secure-monopoly-on-waterdhavian-silk.

--- a/20-Factions/wc-mercers-clothiers/activity/week_0/README.md
+++ b/20-Factions/wc-mercers-clothiers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Mercers & Clothiers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [secure-monopoly-on-waterdhavian-silk.md](secure-monopoly-on-waterdhavian-silk.md)

--- a/20-Factions/wc-mercers-clothiers/activity/week_0/secure-monopoly-on-waterdhavian-silk.md
+++ b/20-Factions/wc-mercers-clothiers/activity/week_0/secure-monopoly-on-waterdhavian-silk.md
@@ -1,0 +1,18 @@
+---
+name: secure-monopoly-on-waterdhavian-silk
+faction: wc-mercers-clothiers
+week: 0
+discovery_dc: 10
+dc: 10
+success: true
+public: true
+---
+
+# Secure a Monopoly on Waterdhavian Silk
+
+[Mistress Elethra Vance](../../people/elethra-vance.md) secures an exclusive import contract with the [Waterdhavian Kontor](../../../waterdhavian-kontor/summary.md) for their high-quality silks, ensuring her guild is the only source for the material most coveted by the city's patriar class for their winter festival gowns.
+
+## See also
+
+- [Worshipful Company of Mercers & Clothiers](../../summary.md)
+- [Waterdhavian Kontor](../../../waterdhavian-kontor/summary.md)

--- a/20-Factions/wc-shipwrights-calkers/README.md
+++ b/20-Factions/wc-shipwrights-calkers/README.md
@@ -6,3 +6,4 @@ Most powerful guild, controlling the city's vital shipbuilding and repair indust
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: helma-tallowshand.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-shipwrights-calkers/activity/README.md
+++ b/20-Factions/wc-shipwrights-calkers/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Shipwrights & Calkers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — sabotage-a-guildless-drydock.

--- a/20-Factions/wc-shipwrights-calkers/activity/week_0/README.md
+++ b/20-Factions/wc-shipwrights-calkers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Shipwrights & Calkers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [sabotage-a-guildless-drydock.md](sabotage-a-guildless-drydock.md)

--- a/20-Factions/wc-shipwrights-calkers/activity/week_0/sabotage-a-guildless-drydock.md
+++ b/20-Factions/wc-shipwrights-calkers/activity/week_0/sabotage-a-guildless-drydock.md
@@ -1,0 +1,19 @@
+---
+name: sabotage-a-guildless-drydock
+faction: wc-shipwrights-calkers
+week: 0
+discovery_dc: 15
+dc: 10
+success: true
+public: true
+---
+
+# Sabotage a Guild-less Drydock
+
+The raid goes awry. The independent operator had hired guards from the [Free Traders of the Outskirts](../../../free-traders-of-the-outskirts/summary.md). The Guild Wardens are intercepted, leading to a bloody skirmish. The Wardens are forced to retreat, and one of their own is captured by the Free Traders, creating a hostage situation and escalating the conflict between the official guilds and Outer City merchants.
+
+## See also
+
+- [Worshipful Company of Shipwrights & Calkers](../../summary.md)
+- [Free Traders of the Outskirts](../../../free-traders-of-the-outskirts/summary.md)
+- [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md)

--- a/20-Factions/wc-smiths-armorers/README.md
+++ b/20-Factions/wc-smiths-armorers/README.md
@@ -5,4 +5,5 @@ Guild forging arms and armor for the city's guards, soldiers, and adventurers.
 ## Index
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
-- [people/](people/) — Named figures: tor-keg-silverhand.
+- [people/](people/) — Named figures: dammon, tor-keg-silverhand.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-smiths-armorers/activity/README.md
+++ b/20-Factions/wc-smiths-armorers/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Smiths & Armorers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — acquire-hell-damaged-armor.

--- a/20-Factions/wc-smiths-armorers/activity/week_0/README.md
+++ b/20-Factions/wc-smiths-armorers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Smiths & Armorers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [acquire-hell-damaged-armor.md](acquire-hell-damaged-armor.md)

--- a/20-Factions/wc-smiths-armorers/activity/week_0/acquire-hell-damaged-armor.md
+++ b/20-Factions/wc-smiths-armorers/activity/week_0/acquire-hell-damaged-armor.md
@@ -1,0 +1,18 @@
+---
+name: acquire-hell-damaged-armor
+faction: wc-smiths-armorers
+week: 0
+discovery_dc: 5
+dc: 5
+success: false
+public: true
+---
+
+# Acquire 'Hell-Damaged' Armor
+
+[Dammon](../../people/dammon.md), of the Forge of the Nine, working at arm's length from Master [Tor-keg Silverhand](../../people/tor-keg-silverhand.md)'s Court of Assistants, puts out a public call to adventuring parties for any armor salvaged from the Fall of Elturel, paying a premium for pieces that are warped by infernal energy, which he believes he can repurpose.
+
+## See also
+
+- [Worshipful Company of Smiths & Armorers](../../summary.md)
+- [Followers of the Phoenix](../../../followers-of-the-phoenix/summary.md) — the cult that venerates the heroine of the Fall.

--- a/20-Factions/wc-smiths-armorers/people/README.md
+++ b/20-Factions/wc-smiths-armorers/people/README.md
@@ -4,4 +4,5 @@ Named figures.
 
 ## Index
 
+- [dammon.md](dammon.md)
 - [tor-keg-silverhand.md](tor-keg-silverhand.md)

--- a/20-Factions/wc-smiths-armorers/people/dammon.md
+++ b/20-Factions/wc-smiths-armorers/people/dammon.md
@@ -1,0 +1,23 @@
+---
+name: dammon
+description: Smith of the Forge of the Nine; pursuing infernal-iron salvage from the Fall of Elturel, beyond the Smiths' Company's full control.
+---
+
+# Dammon
+
+A senior member of the [Worshipful Company of Smiths & Armorers](../summary.md) running his own operation at the **Forge of the Nine**. Master [Tor-keg Silverhand](tor-keg-silverhand.md) neither fully approves nor controls Dammon, and the Court of Assistants is split on whether to discipline him.
+
+## Role
+
+Dammon's specialism is **infernal iron** — armor and steel warped by the Fall of Elturel. He believes he can repurpose hell-damaged metal for new craft. In week 0 he put out a public, premium-pay call to adventuring parties for any salvage from the Fall, and is privately hunting a New Elturel **infernal-contract shard** to weave into his forge-work.
+
+## Pressure points
+
+- His public bounty makes him a natural contact for parties operating in [New Elturel](../../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md) and the [Hinterlands](../../../30-Places/sword-coast/baldurs-gate/hinterlands).
+- [Followers of the Phoenix](../../followers-of-the-phoenix/summary.md) — Karlach is the heroine of the Fall; Dammon's interest in salvage there overlaps awkwardly with their veneration.
+- Tor-keg's Court is watching him; if his work attracts the [Sorcerous Sodality](../../wc-sorcerous-sodality/summary.md) or the [Plague of Remembrance](../../plague-of-remembrance/summary.md), the Court may move against him.
+
+## See also
+
+- [Worshipful Company of Smiths & Armorers](../summary.md)
+- [Master Tor-keg Silverhand](tor-keg-silverhand.md)

--- a/20-Factions/wc-sorcerous-sodality/README.md
+++ b/20-Factions/wc-sorcerous-sodality/README.md
@@ -6,3 +6,4 @@ Reformed Sorcerous Sundries; regulates magical goods and licenses public spellca
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: lorroakan.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-sorcerous-sodality/activity/README.md
+++ b/20-Factions/wc-sorcerous-sodality/activity/README.md
@@ -1,0 +1,7 @@
+# Sorcerous Sodality — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — raid-on-an-unlicensed-spellcaster.

--- a/20-Factions/wc-sorcerous-sodality/activity/week_0/README.md
+++ b/20-Factions/wc-sorcerous-sodality/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Sorcerous Sodality — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [raid-on-an-unlicensed-spellcaster.md](raid-on-an-unlicensed-spellcaster.md)

--- a/20-Factions/wc-sorcerous-sodality/activity/week_0/raid-on-an-unlicensed-spellcaster.md
+++ b/20-Factions/wc-sorcerous-sodality/activity/week_0/raid-on-an-unlicensed-spellcaster.md
@@ -1,0 +1,18 @@
+---
+name: raid-on-an-unlicensed-spellcaster
+faction: wc-sorcerous-sodality
+week: 0
+discovery_dc: 10
+dc: 5
+success: true
+public: false
+---
+
+# Conduct a Raid on an Unlicensed Spellcaster
+
+Acting on a tip, Sodality enforcers raid the attic room of a "hedge wizard" in [Bloomridge](../../../../30-Places/sword-coast/baldurs-gate/lower-city/bloomridge.md) who was selling minor charms and love potions. They confiscate his material components and spellbook, issuing a heavy fine and a stern warning.
+
+## See also
+
+- [Sorcerous Sodality](../../summary.md)
+- [Bloomridge](../../../../30-Places/sword-coast/baldurs-gate/lower-city/bloomridge.md)

--- a/20-Factions/wc-vintners-brewers/README.md
+++ b/20-Factions/wc-vintners-brewers/README.md
@@ -6,3 +6,4 @@ Guild controlling alcohol trade from cheap ale to imported wine; key to social l
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: belba-quickfoot.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wc-vintners-brewers/activity/README.md
+++ b/20-Factions/wc-vintners-brewers/activity/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Vintners & Brewers — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — smash-a-moonshine-operation.

--- a/20-Factions/wc-vintners-brewers/activity/week_0/README.md
+++ b/20-Factions/wc-vintners-brewers/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Worshipful Company of Vintners & Brewers — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [smash-a-moonshine-operation.md](smash-a-moonshine-operation.md)

--- a/20-Factions/wc-vintners-brewers/activity/week_0/smash-a-moonshine-operation.md
+++ b/20-Factions/wc-vintners-brewers/activity/week_0/smash-a-moonshine-operation.md
@@ -1,0 +1,18 @@
+---
+name: smash-a-moonshine-operation
+faction: wc-vintners-brewers
+week: 0
+discovery_dc: 10
+dc: 5
+success: true
+public: true
+---
+
+# Smash a Moonshine Operation
+
+Acting on a tip, Guild Wardens raid a tenement basement in [Eastway](../../../../30-Places/sword-coast/baldurs-gate/lower-city/eastway.md) being used as an illegal distillery. They smash the stills and confiscate the moonshine, making an example of the operator to discourage others from bypassing the guild's monopoly.
+
+## See also
+
+- [Worshipful Company of Vintners & Brewers](../../summary.md)
+- [Eastway](../../../../30-Places/sword-coast/baldurs-gate/lower-city/eastway.md)

--- a/20-Factions/western-gate-trading-company/README.md
+++ b/20-Factions/western-gate-trading-company/README.md
@@ -6,3 +6,4 @@ Patriar-backed consortium controlling overland routes and hinterland resources; 
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: lyra-silvershield.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/western-gate-trading-company/activity/README.md
+++ b/20-Factions/western-gate-trading-company/activity/README.md
@@ -1,0 +1,7 @@
+# Western Gate Trading Company — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — clear-cut-the-whisperwood-copse.

--- a/20-Factions/western-gate-trading-company/activity/week_0/README.md
+++ b/20-Factions/western-gate-trading-company/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Western Gate Trading Company — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [clear-cut-the-whisperwood-copse.md](clear-cut-the-whisperwood-copse.md)

--- a/20-Factions/western-gate-trading-company/activity/week_0/clear-cut-the-whisperwood-copse.md
+++ b/20-Factions/western-gate-trading-company/activity/week_0/clear-cut-the-whisperwood-copse.md
@@ -1,0 +1,21 @@
+---
+name: clear-cut-the-whisperwood-copse
+faction: western-gate-trading-company
+week: 0
+discovery_dc: 5
+dc: 5
+success: true
+public: true
+---
+
+# Clear-Cut the Whisperwood Copse
+
+Using their newly-ratified charter, Matron [Lyra Silvershield's](../../people/lyra-silvershield.md) company dispatches logging crews to a section of the [Wood of Sharp Teeth](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/README.md) known locally as the **Whisperwood Copse**. They clear-cut the area with brutal efficiency, enraging the [Circle of the Inner Grove](../../../circle-of-the-inner-grove/summary.md).
+
+## See also
+
+- [Western Gate Trading Company](../../summary.md)
+- [Circle of the Inner Grove](../../../circle-of-the-inner-grove/summary.md) — their warding ritual was a direct response.
+- [Sembian Kontor](../../../sembian-kontor/summary.md) — brokered the mercenary cover for the loggers.
+- [Council of Four](../../../council-of-four/summary.md) — Durinbold tabled the parallel charter motion the same week.
+- [Wood of Sharp Teeth (local face)](../../../../30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/README.md)

--- a/20-Factions/wharf-rats/README.md
+++ b/20-Factions/wharf-rats/README.md
@@ -6,3 +6,4 @@ Dockside smuggling crew under One-Eyed Jack, working the Gray Harbour.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: one-eyed-jack.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/wharf-rats/activity/README.md
+++ b/20-Factions/wharf-rats/activity/README.md
@@ -1,0 +1,7 @@
+# Wharf Rats — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — lose-a-crate-of-lantaner-goods.

--- a/20-Factions/wharf-rats/activity/week_0/README.md
+++ b/20-Factions/wharf-rats/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Wharf Rats — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [lose-a-crate-of-lantaner-goods.md](lose-a-crate-of-lantaner-goods.md)

--- a/20-Factions/wharf-rats/activity/week_0/lose-a-crate-of-lantaner-goods.md
+++ b/20-Factions/wharf-rats/activity/week_0/lose-a-crate-of-lantaner-goods.md
@@ -1,0 +1,19 @@
+---
+name: lose-a-crate-of-lantaner-goods
+faction: wharf-rats
+week: 0
+discovery_dc: 15
+dc: 10
+success: true
+public: false
+---
+
+# 'Lose' a Crate of Lantaner Goods
+
+[One-Eyed Jack's](../../people/one-eyed-jack.md) dockworkers contrive to "accidentally" drop a crate from the [Lantaner Concession](../../../lantaner-concession/summary.md) during unloading at [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md). The crate, containing valuable mechanical parts, is damaged and its contents are pilfered before being reported as a loss.
+
+## See also
+
+- [Wharf Rats](../../summary.md)
+- [Lantaner Concession](../../../lantaner-concession/summary.md)
+- [Gray Harbour](../../../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md)

--- a/20-Factions/zhentarim/README.md
+++ b/20-Factions/zhentarim/README.md
@@ -6,3 +6,4 @@ Ruthless profit-driven criminal network seeking to supplant the Guild.
 
 - [summary.md](summary.md) — Faction overview: ideology, membership, methods, hooks.
 - [people/](people/) — Named figures: roah-moonglow.
+- [activity/](activity/) — Ongoing actions by week (week_0).

--- a/20-Factions/zhentarim/activity/README.md
+++ b/20-Factions/zhentarim/activity/README.md
@@ -1,0 +1,7 @@
+# Zhentarim — activity
+
+Ongoing actions, organized by in-game week.
+
+## Index
+
+- [week_0/](week_0/) — burn-down-a-guild-protected-tavern.

--- a/20-Factions/zhentarim/activity/week_0/README.md
+++ b/20-Factions/zhentarim/activity/week_0/README.md
@@ -1,0 +1,7 @@
+# Zhentarim — activity — week_0
+
+Actions taken in week_0.
+
+## Index
+
+- [burn-down-a-guild-protected-tavern.md](burn-down-a-guild-protected-tavern.md)

--- a/20-Factions/zhentarim/activity/week_0/burn-down-a-guild-protected-tavern.md
+++ b/20-Factions/zhentarim/activity/week_0/burn-down-a-guild-protected-tavern.md
@@ -1,0 +1,20 @@
+---
+name: burn-down-a-guild-protected-tavern
+faction: zhentarim
+week: 0
+discovery_dc: 15
+dc: 10
+success: true
+public: true
+---
+
+# Burn Down a Guild-Protected Tavern
+
+As part of their move on [Brampton](../../../../30-Places/sword-coast/baldurs-gate/lower-city/brampton.md), [Roah Moonglow's](../../people/roah-moonglow.md) enforcers burn down a tavern that refused to switch its protection payments from [The Guild](../../../guild/summary.md) to them. The act is meant as a brutal message to other businesses in the area.
+
+## See also
+
+- [Zhentarim](../../summary.md)
+- [The Guild](../../../guild/summary.md)
+- [River-Rats](../../../river-rats/summary.md) — the Guild crew operating beneath the same district.
+- [Brampton](../../../../30-Places/sword-coast/baldurs-gate/lower-city/brampton.md)

--- a/30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/events.md
+++ b/30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/events.md
@@ -1,0 +1,17 @@
+---
+name: wood-of-sharp-teeth-events
+description: What happened at the Wood of Sharp Teeth's western edge by in-game week.
+---
+
+# Wood of Sharp Teeth — Events
+
+## Week 0
+
+- **Whisperwood Copse clear-cut.** [Western Gate Trading Company](../../../../../20-Factions/western-gate-trading-company/summary.md) loggers, under Matron [Lyra Silvershield's](../../../../../20-Factions/western-gate-trading-company/people/lyra-silvershield.md) newly-ratified hinterland charter, cut a section of the wood known locally as the Whisperwood Copse with brutal efficiency. See [activity](../../../../../20-Factions/western-gate-trading-company/activity/week_0/clear-cut-the-whisperwood-copse.md).
+- **Sembian mercenary cover deployed.** The [Sembian Kontor](../../../../../20-Factions/sembian-kontor/summary.md) brokered a tough mercenary band to "protect" the loggers from "bandits" — a euphemism for the [Circle of the Inner Grove](../../../../../20-Factions/circle-of-the-inner-grove/summary.md). See [activity](../../../../../20-Factions/sembian-kontor/activity/week_0/broker-a-mercenary-contract.md).
+- **Ritual of Warding goes wrong.** [Elder Elion's](../../../../../20-Factions/circle-of-the-inner-grove/people/elder-elion.md) attempt to ward the wood was corrupted by lingering infernal energy and twisted local wildlife into fiendish, aggressive versions that now attack loggers and druids alike. See [activity](../../../../../20-Factions/circle-of-the-inner-grove/activity/week_0/perform-a-ritual-of-warding.md).
+
+## See also
+
+- [README.md](README.md) — local description.
+- [character.md](character.md), [factions.md](factions.md).

--- a/30-Places/sword-coast/baldurs-gate/lower-city/events.md
+++ b/30-Places/sword-coast/baldurs-gate/lower-city/events.md
@@ -1,0 +1,38 @@
+---
+name: lower-city-events
+description: What happened in the Lower City districts by in-game week.
+---
+
+# Lower City — Events
+
+## Week 0
+
+### Gray Harbour
+
+- **Harbor Dredging Levy passed.** [Peerage of Coin](../../../../20-Factions/peerage-of-coin/summary.md) lobbied through a new levy on non-guild vessels; cost passes to independents. See [activity](../../../../20-Factions/peerage-of-coin/activity/week_0/push-through-the-harbor-dredging-levy.md).
+- **Dockworker strike collapses.** Refugee strikebreakers hired by the [Chionthar Consortium](../../../../20-Factions/chionthar-consortium/summary.md) broke the [Worshipful Company of Fishmongers'](../../../../20-Factions/wc-fishmongers/summary.md) strike within hours. See [activity](../../../../20-Factions/wc-fishmongers/activity/week_0/organize-a-dockworker-strike.md).
+- **Shipwrights' raid turns hostage standoff.** A Guild Wardens raid on a Free-Trader-protected drydock ended with a captured Warden. See [activity](../../../../20-Factions/wc-shipwrights-calkers/activity/week_0/sabotage-a-guildless-drydock.md).
+- **Lantaner schematic walks out of the Cogwork Quay.** A Lantaner apprentice spy escaped with partial smokepowder schematics, delivered to the [Worshipful Company of Smiths & Armorers](../../../../20-Factions/wc-smiths-armorers/summary.md). See [activity](../../../../20-Factions/lantaner-concession/activity/week_0/root-out-an-industrial-spy.md).
+- **Wharf Rats "lose" a Lantaner crate.** [One-Eyed Jack's](../../../../20-Factions/wharf-rats/people/one-eyed-jack.md) dockworkers staged an accident; mechanical parts pilfered. See [activity](../../../../20-Factions/wharf-rats/activity/week_0/lose-a-crate-of-lantaner-goods.md).
+
+### Bloomridge
+
+- **Carnival of Whispers abduction goes loud.** Their target, a skilled fencer, fought back; Bloomridge is now watching for sinister clowns. See [activity](../../../../20-Factions/carnival-of-whispers/activity/week_0/abduct-a-passionate-soul.md).
+- **Sorcerous Sodality raid on a hedge wizard.** Components and spellbook confiscated; heavy fine and warning. See [activity](../../../../20-Factions/wc-sorcerous-sodality/activity/week_0/raid-on-an-unlicensed-spellcaster.md).
+
+### Brampton
+
+- **River-Rats establish a new sewer cache.** Silas the Eel's crew secured a defensible sewer nexus to bypass Wyrm's Crossing patrols. See [activity](../../../../20-Factions/river-rats/activity/week_0/establish-a-new-sewer-cache.md).
+- **Zhentarim arson on a Guild-protected tavern.** Roah Moonglow's enforcers burned a refusing tavern as a territorial message. See [activity](../../../../20-Factions/zhentarim/activity/week_0/burn-down-a-guild-protected-tavern.md).
+
+### Heapside
+
+- **Bhaal cult kidnapping.** A homeless man was taken from a Heapside alley to consecrate a sewer altar in the Undercity. See [activity](../../../../20-Factions/cult-of-the-returning-lord/activity/week_0/consecrate-a-sewer-altar.md).
+
+### Eastway
+
+- **Vintners' moonshine raid.** Guild Wardens smashed a tenement-basement distillery and confiscated stock. See [activity](../../../../20-Factions/wc-vintners-brewers/activity/week_0/smash-a-moonshine-operation.md).
+
+## See also
+
+- [README.md](README.md) — Lower City overview.

--- a/30-Places/sword-coast/baldurs-gate/outer-city/events.md
+++ b/30-Places/sword-coast/baldurs-gate/outer-city/events.md
@@ -1,0 +1,30 @@
+---
+name: outer-city-events
+description: What happened in the Outer City districts by in-game week.
+---
+
+# Outer City — Events
+
+## Week 0
+
+### Wyrm's Crossing
+
+- **Flaming Fist shakedowns backfire.** [Manip Jerrol's](../../../../20-Factions/flaming-fist/people/manip-jerrol.md) escalation triggered a public brawl with ['Mad' Meggan](../../../../20-Factions/free-traders-of-the-outskirts/people/mad-meggan.md) and a multi-day Free Trader blockade of the bridge. See [activity](../../../../20-Factions/flaming-fist/activity/week_0/increased-shakedowns-on-wyrms-crossing.md).
+- **Mutual-protection pact signed.** Free Trader caravan masters formalize convoys and intelligence-sharing on Fist patrols. See [activity](../../../../20-Factions/free-traders-of-the-outskirts/activity/week_0/establish-a-mutual-protection-pact.md).
+
+### New Elturel
+
+- **First Phoenix sermon.** [The Ember](../../../../20-Factions/followers-of-the-phoenix/people/the-ember.md) preached publicly in an abandoned square; a small crowd of tieflings and outcasts answered. See [activity](../../../../20-Factions/followers-of-the-phoenix/activity/week_0/hold-a-sermon-in-new-elturel.md).
+- **Hellrider citizenship petition leaked.** A patriar aide leaked the High Hall petition with a falsified cost-analysis to the [Baldur's Mouth](../../../../20-Factions/baldurs-mouth/summary.md), souring public opinion. See [activity](../../../../20-Factions/hellriders-of-new-elturel/activity/week_0/submit-petition-for-citizenship.md).
+- **Refugee Relief Act shelved.** [Peerage of Blood](../../../../20-Factions/peerage-of-blood/summary.md) filibuster killed the bill in [Parliament](../../../../20-Factions/parliament-of-peers/summary.md). See [activity](../../../../20-Factions/parliament-of-peers/activity/week_0/debate-the-refugee-relief-act.md).
+- **Guild winter relief distributed.** [Nine-Fingers Keene's](../../../../20-Factions/guild/people/astele-keene.md) Ward Bosses ran blankets and food into the camps. See [activity](../../../../20-Factions/guild/activity/week_0/organize-winter-relief-for-new-elturel.md).
+- **Refugee strikebreakers hired.** The [Chionthar Consortium](../../../../20-Factions/chionthar-consortium/summary.md) recruited refugee labor to break the Wharf Rats' strike, poisoning relations between Baldurian dockers and Elturians. See [activity](../../../../20-Factions/wc-fishmongers/activity/week_0/organize-a-dockworker-strike.md).
+- **Waterdhavian agents pry "lost" Elturian tomes.** Factor Elara Mornwood acquired rare historical texts from a refugee scholar at a humiliating price. See [activity](../../../../20-Factions/waterdhavian-kontor/activity/week_0/acquire-lost-elturian-tomes.md).
+
+### Tumbledown and Floodway
+
+- **Gravekeepers cleansing interrupted.** A wraith broke a key warding stone before the Gravekeepers put it down; the graveyard is more vulnerable than before. See [activity](../../../../20-Factions/gravekeepers/activity/week_0/perform-a-cleansing-ritual-in-tumbledown.md).
+
+## See also
+
+- [README.md](README.md) — Outer City overview.

--- a/30-Places/sword-coast/baldurs-gate/undercity/events.md
+++ b/30-Places/sword-coast/baldurs-gate/undercity/events.md
@@ -1,0 +1,16 @@
+---
+name: undercity-events
+description: What happened in the Undercity by in-game week.
+---
+
+# Undercity — Events
+
+## Week 0
+
+- **Bhaalist sewer altar consecrated.** [Cult of the Returning Lord](../../../../20-Factions/cult-of-the-returning-lord/summary.md) cultists murdered a kidnapped homeless man on a makeshift altar, consecrating the space for future, more important rituals. See [activity](../../../../20-Factions/cult-of-the-returning-lord/activity/week_0/consecrate-a-sewer-altar.md).
+- **Undercellar counterfeiter shut down.** [Master Theronius Goldhand's](../../../../20-Factions/wc-goldsmiths-jewelers/people/theronius-goldhand.md) agents and [The Guild](../../../../20-Factions/guild/summary.md) jointly identified and closed a small-time counterfeiter operating out of [the Undercellar](the-undercellar.md). See [activity](../../../../20-Factions/wc-goldsmiths-jewelers/activity/week_0/expose-a-counterfeit-operation.md).
+
+## See also
+
+- [README.md](README.md) — Undercity overview.
+- [the-undercellar.md](the-undercellar.md).

--- a/30-Places/sword-coast/baldurs-gate/upper-city/events.md
+++ b/30-Places/sword-coast/baldurs-gate/upper-city/events.md
@@ -1,0 +1,20 @@
+---
+name: upper-city-events
+description: What happened in the Upper City districts by in-game week.
+---
+
+# Upper City — Events
+
+## Week 0
+
+### Manorborn
+
+- **Hlath estate foreclosure finalized.** [Consul Vorlamin Athar's](../../../../20-Factions/amnian-kontor/people/vorlamin-athar.md) Amnian agents evicted [Lord Hlath](../../../../20-Factions/peerage-of-blood/people/lord-hlath.md) over gambling debts; the Kontor now owns a prime piece of Manorborn. See [activity](../../../../20-Factions/amnian-kontor/activity/week_0/finalize-foreclosure-on-the-hlath-estate.md).
+- **Knights of the Shield exposed at the Watchful Shield Shrine.** The Knights tried to recruit Hlath; he refused and anonymously tipped off a priest at the shrine, alerting Helm's faithful to the order's resurgence. See [activity](../../../../20-Factions/knights-of-the-shield/activity/week_0/recruit-a-dispossessed-patriar.md).
+- **"Baldurian Purity" gala.** [Lord Corin Durinbold](../../../../20-Factions/peerage-of-blood/people/corin-durinbold.md) hosted the Peerage of Blood for a thinly veiled rally against the foreign Kontors. See [activity](../../../../20-Factions/patriar-heritage-society/activity/week_0/host-a-baldurian-purity-gala.md).
+- **Jannath Estate vandalism written off.** Red paint splashed on the estate's "foreign-style" Sembian statues was dismissed as youthful hijinks by the Watch — actually a [Society of Baldurian Integrity](../../../../20-Factions/society-of-baldurian-integrity/summary.md) statement. See [activity](../../../../20-Factions/watch/activity/week_0/investigate-vandalism-at-the-jannath-estate.md).
+
+## See also
+
+- [README.md](README.md) — Upper City overview.
+- [manorborn.md](manorborn.md), [character.md](character.md).

--- a/40-Timeline/week_0/events.md
+++ b/40-Timeline/week_0/events.md
@@ -1,0 +1,38 @@
+---
+name: week-0-events
+description: Visible-summary timeline of week 0 (early spring 1502 DR) — opening fronts across the hinterlands, Wyrm's Crossing, refugee politics, trade war, and the first cult traces.
+---
+
+# Week 0 — Events
+
+Early spring, 1502 DR. The week the campaign's fronts open — almost entirely off-camera from the eventual party.
+
+## Hinterlands and the Whisperwood
+
+The [Western Gate](../../20-Factions/western-gate-trading-company/summary.md) clear-cuts the [Whisperwood Copse](../../30-Places/sword-coast/baldurs-gate/hinterlands/wood-of-sharp-teeth/README.md); the [Sembian Kontor](../../20-Factions/sembian-kontor/summary.md) brokers a mercenary band as "anti-bandit" cover. The [Circle of the Inner Grove's](../../20-Factions/circle-of-the-inner-grove/summary.md) [Elder Elion](../../20-Factions/circle-of-the-inner-grove/people/elder-elion.md) answers with a Ritual of Warding — corrupted by infernal residue into a blight that twists wildlife into fiendish forms. In the Council, [Lord Corin Durinbold](../../20-Factions/peerage-of-blood/people/corin-durinbold.md) tables the parallel charter on a procedural loophole, bruising Archduke [Lyra Silvershield](../../20-Factions/western-gate-trading-company/people/lyra-silvershield.md) even as her saws keep running.
+
+## Wyrm's Crossing pressure spike
+
+[Manip Jerrol's](../../20-Factions/flaming-fist/people/manip-jerrol.md) Flaming Fist shakedowns at [Wyrm's Crossing](../../30-Places/sword-coast/baldurs-gate/outer-city/wyrms-crossing.md) backfire into a brawl with ['Mad' Meggan](../../20-Factions/free-traders-of-the-outskirts/people/mad-meggan.md) and a multi-day Free Trader blockade; the [Free Traders](../../20-Factions/free-traders-of-the-outskirts/summary.md) formalize a mutual-protection pact in response. The [River-Rats](../../20-Factions/river-rats/summary.md) try to seat a new sewer cache in [Brampton](../../30-Places/sword-coast/baldurs-gate/lower-city/brampton.md); the [Zhentarim](../../20-Factions/zhentarim/summary.md) burn a Guild-protected tavern in the same district as a territorial message.
+
+## Refugee politics harden
+
+The [Hellriders'](../../20-Factions/hellriders-of-new-elturel/summary.md) citizenship petition is leaked with a falsified cost-analysis to the [Baldur's Mouth](../../20-Factions/baldurs-mouth/summary.md); the [Peerage of Blood](../../20-Factions/peerage-of-blood/summary.md) filibusters the Refugee Relief Act dead in [Parliament](../../20-Factions/parliament-of-peers/summary.md). The [Plague of Remembrance's](../../20-Factions/plague-of-remembrance/summary.md) Lady Vhage seeds an Upper-City rumor campaign blaming refugees for crime and disease. [The Guild's](../../20-Factions/guild/summary.md) [Nine-Fingers Keene](../../20-Factions/guild/people/astele-keene.md) counters with public winter-relief in [New Elturel](../../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md), embarrassing the city's leaders.
+
+## Trade and property war
+
+The [Amnian Kontor](../../20-Factions/amnian-kontor/summary.md) forecloses on [Lord Hlath](../../20-Factions/peerage-of-blood/people/lord-hlath.md). The [Peerage of Coin](../../20-Factions/peerage-of-coin/summary.md) passes a Harbor Dredging Levy that hits independents; the [Peerage of Blood](../../20-Factions/peerage-of-blood/summary.md) blocks the Amnian "Wayleave" off a [Patriar Heritage Society](../../20-Factions/patriar-heritage-society/summary.md) gala. The Sembian Kontor outbids [Master Joric](../../20-Factions/chionthar-consortium/people/joric-the-stout.md) on warehousing, worsening [Chionthar](../../20-Factions/chionthar-consortium/summary.md) rates. The [Fishmongers'](../../20-Factions/wc-fishmongers/summary.md) dockworker strike collapses within hours when the Consortium hires refugee strikebreakers — poisoning Baldurian/Elturian solidarity. Smaller plays: Alchemist antitoxin price-gouge, Mercer silk monopoly, a Shipwrights raid turned hostage standoff at [Gray Harbour](../../30-Places/sword-coast/baldurs-gate/lower-city/gray-harbour.md), and [Dammon's](../../20-Factions/wc-smiths-armorers/people/dammon.md) bounty for hell-damaged armor.
+
+## Hidden fronts leave first traces
+
+The [Cult of the Returning Lord](../../20-Factions/cult-of-the-returning-lord/summary.md) consecrates a Bhaalist sewer altar with a kidnapped man's blood. The [Hands of the Absolute](../../20-Factions/hands-of-the-absolute/summary.md) reach for the Echo and touch a feral psychic entity that kills one cultist and breaks another. The [Gravekeepers'](../../20-Factions/gravekeepers/summary.md) Tumbledown cleansing ends with a shattered warding stone. The [Purified](../../20-Factions/purified/summary.md), [Silent Shroud](../../20-Factions/silent-shroud/summary.md), [Carnival of Whispers](../../20-Factions/carnival-of-whispers/summary.md), [Takers of the Tithe](../../20-Factions/takers-of-the-tithe/summary.md) and [Gilded Vein](../../20-Factions/gilded-vein/summary.md) bungle their openings and burn operatives. The [Knights of the Shield](../../20-Factions/knights-of-the-shield/summary.md) approach Lord Hlath; he refuses and tips the Watchful Shield Shrine. The [Followers of the Phoenix](../../20-Factions/followers-of-the-phoenix/summary.md) hold their first public sermon under [the Ember](../../20-Factions/followers-of-the-phoenix/people/the-ember.md). The [Harpers](../../20-Factions/harpers/summary.md) plant a now-misled agent in the Masons; a Lantaner apprentice walks a smokepowder schematic out to the Smiths.
+
+## From PC actions
+
+The party is not on the board. `player-companion.docx` has no Week 0 section — the campaign source jumps to Week 1, where Sessions 1–3 begin. PC consequences for these fronts start landing in week 1.
+
+## See also
+
+- [calendar.md](../calendar.md) — week-0 anchor (early spring, 1502 DR).
+- Per-row activity detail: `20-Factions/<slug>/activity/week_0/`.
+- Place fallout: `30-Places/sword-coast/baldurs-gate/<district>/events.md`.


### PR DESCRIPTION
## Summary

- Lands the 51 faction activity files for week 0 from `faction-quests.xlsx` under `20-Factions/<slug>/activity/week_0/`, plus the visible-summary `40-Timeline/week_0/events.md`, district `events.md` files under `30-Places/`, and the party canon foundation.
- Each activity file carries frontmatter (`faction`, `week`, `discovery_dc`, `dc`, `success`, `public`) and a narrative body — no `## Roll` mechanics paste-in.
- Timeline synthesizes the week into five readable beats (hinterlands/Whisperwood, Wyrm's Crossing pressure, refugee politics, trade war, hidden fronts).

## Changes

- `20-Factions/<slug>/activity/week_0/<quest-slug>.md` — 51 files, one per row.
- `20-Factions/party/summary.md` filled (PCs: Bror, Spark, Elia Thorne, Kaelan; Finn and Jaredith handled as NPC allies under their factions).
- New NPC pages: `flaming-fist/people/manip-jerrol.md`, `peerage-of-blood/people/lord-hlath.md`, `wc-smiths-armorers/people/dammon.md`.
- Activity-file links repointed to canonical NPC slugs (joric-the-stout, elder-elion, astele-keene, emmeline-vhage, k-laar, borlu).
- District events: `30-Places/sword-coast/baldurs-gate/{lower-city,upper-city,outer-city,undercity}/events.md` and `hinterlands/wood-of-sharp-teeth/events.md`.
- `40-Timeline/week_0/events.md` (≈491 prose words; under the 500-word limit when link URLs are excluded).
- `scaffold_factions.py` refreshed per-folder READMEs.

## Notes

- `player-companion.docx` has no `# Week 0` section — the campaign source jumps to Week 1, where Sessions 1–3 begin. Per issue #26's instruction, the timeline notes this and skips week-0 sessions / `party/activity/week_0/`.
- Existing faction summaries already absorbed the week-0 durable canon from prior dossier work (`hands-of-the-absolute`, `knights-of-the-shield`, `free-traders-of-the-outskirts`, etc.); no rewrites needed there.
- Source-flag `success`/`public` values are preserved verbatim in frontmatter; descriptions carry the narrative outcome (which sometimes diverges from the source flag — the row-author's editorial choice, not normalized here).

## Test plan

- [ ] Skim a sample of activity files for shape and link integrity.
- [ ] Verify `40-Timeline/week_0/events.md` reads as a coherent week.
- [ ] Confirm `scaffold_factions.py` output is idempotent on a re-run.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)