### PR TITLE
Ingest the Sea of Swords regional dossier (#20)

### DIFF
--- a/00-Campaign-Frame/README.md
+++ b/00-Campaign-Frame/README.md
@@ -9,5 +9,7 @@ Evergreen rules of the world: the "physics," the psychology, and the psychosis u
 - [class-and-survival.md](class-and-survival.md) — the Wretched-to-Aristocratic ladder is a literal agency ladder.
 - [fey-bargains.md](fey-bargains.md) — How fey contracts work: favors as currency, debt as bondage, the letter is the law, a name is a handle.
 - [frontier-logic.md](frontier-logic.md) — Outside the city walls, jurisdiction blurs and "law" is whoever shows up with steel.
+- [multipolar-coast.md](multipolar-coast.md) — No single sovereign rules the Sword Coast; power is brokered between cities, Kontors, pirate fleets, and sea-cults.
+- [sea-as-frontier.md](sea-as-frontier.md) — The Sea of Swords is lifeline and threat; piracy and tribute are structural, not anomalous.
 - [the-masquerade-rule.md](the-masquerade-rule.md) — Performance is power and identity is currency; why masks both protect and bind.
 - [veils-and-masks.md](veils-and-masks.md) — Public power and real power are different; the surface is theater, the truth is masked.

--- a/00-Campaign-Frame/multipolar-coast.md
+++ b/00-Campaign-Frame/multipolar-coast.md
@@ -1,0 +1,38 @@
+---
+name: multipolar-coast
+description: Evergreen rule — no single sovereign rules the Sword Coast; power is brokered between cities, Kontors, pirate fleets, and the sea-cults.
+---
+
+# Multipolar Coast
+
+No king sits over the Sword Coast. The political map of the western coast is an unstable balance of city-states, foreign trading empires, pirate confederations, and a small number of sea-cults whose veto runs underwater. None of the surface powers can defeat any of the others; all of them spend most of their effort pretending otherwise.
+
+## The principle
+
+The coast is **multipolar by design**, not by accident. Every attempt at hegemony in living memory has failed: Bloodwave's Black Flag Fleet shattered at Asavir's Channel (1498 DR); Amn's claim on the Moonshaes contained to Snowdown; the Lords' Alliance forts on the High Road are a Waterdhavian *aspiration*, not an achieved order. Power is brokered, not held — and the brokerage happens through trade alliances, Kontor enclaves, mercenary contracts, and outright bribery.
+
+## The blocs in 1502 DR
+
+- **Lords' Alliance.** Waterdeep-led mutual-defense pact. See [10-Setting/polities/lords-alliance.md](../10-Setting/polities/lords-alliance.md). Strong on paper, hollow at the edges; cannot enforce a regional rule.
+- **Sword Coast Hansa.** Informal, Baldur's-Gate-centered trade bloc. See [10-Setting/polities/sword-coast-hansa.md](../10-Setting/polities/sword-coast-hansa.md). Commercial, not military; binds smaller polities through tariffs and shared courts.
+- **Luskan and the Pirate Coast.** The Five High Captains, the Arcane Brotherhood, the Nelanther, and Mintarn — each independent, all hostile to Alliance overreach. See [10-Setting/polities/luskan-and-the-pirates.md](../10-Setting/polities/luskan-and-the-pirates.md).
+- **Calimshan and Amn.** Southern powers projecting up into the coast — Amnian banking through the [Amnian Kontor](../20-Factions/amnian-kontor/summary.md), Calishite spices through Athkatla, both quietly funding privateers. See [10-Setting/polities/calimshan-amn.md](../10-Setting/polities/calimshan-amn.md).
+- **The Moonshaes and the North.** Crown-and-fey rule on Alaron and Gwynneth; Storm Maiden reavers on the Northlander isles; Ruathym closed entirely. Not aligned with any mainland bloc.
+- **Underwater vetoes.** Umberlee's clergy and the Kraken Society. Not surface polities; effective vetoes on coastal shipping nonetheless.
+
+## How it shows up
+
+- **No flag works everywhere.** Captains keep multiple flags and read the room. See [sea-as-frontier.md](sea-as-frontier.md).
+- **Proxy wars at sea.** Amn issues letters of marque to Nelanther pirates against Waterdhavian shipping; Waterdeep funds Northlander reavers against Luskan. Today's pirate scourge is on someone's payroll.
+- **Conferences in neutral ports.** Mintarn and Skaug make their living off the *absence* of a hegemon — neutral parley-grounds nobody can hold inside their own walls.
+- **No regional adjudication.** Inter-bloc disputes resolve through bilateral pressure or proxy violence; no body could arbitrate.
+
+## What this means at the table
+
+- **Single-bloc framing is wrong.** The coast is six actors; ask which one applies before assuming any of them.
+- **Coalitions are situational.** Hansa and Alliance share interests on anti-piracy and oppose each other on tariffs in the same week.
+- **Hegemony is dramatic.** Any move that tips the balance — Luskan accession, Amnian annexation of Snowdown, a Hansa fleet — is a campaign-scale event because everyone else moves to prevent it.
+
+## Source
+
+Inferred from `.context/converted/dossier-sea-of-swords.md` — particularly the Trade Routes chapter and the Mintarn / Luskan sections, where the dossier explicitly maps brokerage and proxy as the working order of the coast.

--- a/00-Campaign-Frame/sea-as-frontier.md
+++ b/00-Campaign-Frame/sea-as-frontier.md
@@ -1,0 +1,33 @@
+---
+name: sea-as-frontier
+description: Evergreen rule — the Sea of Swords is lifeline and threat in equal measure; piracy and salt-cult tribute are structural, not anomalous.
+---
+
+# Sea as Frontier
+
+The Sword Coast lives by the sea. Every walled city the campaign cares about — Waterdeep, Baldur's Gate, Luskan, Athkatla — pays its bills off ship-traffic that runs through waters no polity actually controls. The water is not a road; it is a frontier with the same physics as [frontier-logic.md](frontier-logic.md): patrols exist at points, sovereignty exists only inside the harbor mouth, and everything in between belongs to whoever shows up with sail and steel.
+
+## The principle
+
+The Sea of Swords is **commercial infrastructure that no one owns**. Cargo crosses it because the captains who carry the cargo treat the sea as a working partner — feed it tribute, respect its weather, name your gods aloud — and pay tax to whichever flag happens to be in sight. Piracy is not deviance from the system; piracy *is* the system, alternating with privateering and Lords' Alliance patrols depending on which week and which coastline.
+
+## How it shows up
+
+- **Tribute as price-of-passage.** Umberlee's tithe and the Skaug dock-boss bribe are the same kind of cost. A captain who refuses either does not last a season.
+- **Three flags in the locker.** Smugglers and Zhentarim cutters keep multiple colors and switch as the weather changes. Identity at sea is performative — see [the-masquerade-rule.md](the-masquerade-rule.md).
+- **Monsters are weather.** Sea hags, sahuagin, the Kraken's whisper — not common, but known costs of doing business. Not all problems are political.
+- **The deep keeps memory.** Wrecks, ghost ships, sunken cities (Ascarle off the Purple Rocks). Recent stirrings there (1501 DR Harper missive) are an *event*, not a rumor.
+
+## What this means at the table
+
+- **Sea travel is not safe but it is not adventure either.** Rolling the dice on a coastal run is what merchants do every day. Players running cargo are paying ordinary tribute, not embarking on a campaign arc — until the dice surface something the merchants would also have called an event.
+- **Faction patrols are partial.** The Lords' Alliance patrols the Sword Coast Run from Waterdeep to Orlumbor; Baldur's Gate runs convoys to Candlekeep; nobody patrols Asavir's Channel without a fleet. The map of "safe water" is small and seasonal.
+- **Coastal authority stops at the gate.** A city's writ ends at its harbor mouth. The customs officer on the quay is the last piece of "law" you will see until the next harbor — and even his fee is a negotiation.
+
+## Where it's most visible
+
+The Sword Coast Run between Waterdeep and Baldur's Gate; the Nelanther bottleneck at Asavir's Channel; the Mintarn neutral-port economy; Luskan's two-faced harbor (Whitesails inside, Open Shore outside).
+
+## Source
+
+Inferred from `.context/converted/dossier-sea-of-swords.md` — Greywake's prologue and the Trade Routes chapter, both of which treat the sea as a shared, unowned working space rather than as territory.

--- a/10-Setting/CONTRIBUTING.md
+++ b/10-Setting/CONTRIBUTING.md
@@ -14,6 +14,7 @@ cosmology/      # planar physics, cosmic powers, fey courts, the Weave, the Far 
   realms/       # non-Material planes treated as places (Feywild, Shadowfell, etc.)
 history/        # dated world-visible events; chronology lives in 40-Timeline
 polities/       # alliance-, kingdom-, and city-government frameworks (Lords' Alliance, Sword Coast Hansa, Worshipful Company system)
+regions/        # region-scale geographic features (Sea of Swords, mountain ranges)
 peoples/        # diasporas and demographic groups
 economy/        # cost-of-living and commercial reference
 ```

--- a/10-Setting/README.md
+++ b/10-Setting/README.md
@@ -13,6 +13,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the layout convention.
 
 - [cosmology/](cosmology/) — Planar physics and cosmic powers; the [fey courts](cosmology/fey-courts/), the [Far Realm](cosmology/far-realm.md), and non-Material [realms](cosmology/realms/).
 - [history/](history/README.md) — dated events at world-visible scale; the foundational catastrophes and reformations.
-- [polities/](polities/README.md) — institutional frameworks: trade alliances, governing systems, guild structures, and city governments (including [waterdeep-government.md](polities/waterdeep-government.md)).
+- [polities/](polities/README.md) — institutional frameworks: trade alliances, governing systems, guild structures, and city governments (including [waterdeep-government.md](polities/waterdeep-government.md), [lords-alliance.md](polities/lords-alliance.md), [luskan-and-the-pirates.md](polities/luskan-and-the-pirates.md), [calimshan-amn.md](polities/calimshan-amn.md)).
+- [regions/](regions/README.md) — region-scale geographic features (the [Sea of Swords](regions/sea-of-swords.md)).
 - [peoples/](peoples/README.md) — diasporas and demographic groups.
 - [economy/](economy/README.md) — cost-of-living and commercial reference.

--- a/10-Setting/polities/README.md
+++ b/10-Setting/polities/README.md
@@ -9,5 +9,9 @@ Institutional frameworks at the *system* level. Specific instances live in `20-F
 
 ## Index
 
+- [calimshan-amn.md](calimshan-amn.md) — the southern powers (Amn, Calimshan) projecting into Sword Coast affairs.
+- [lords-alliance.md](lords-alliance.md) — the formal Waterdeep-led mutual-defense and trade pact of the Sword Coast North.
+- [luskan-and-the-pirates.md](luskan-and-the-pirates.md) — the Luskan / Arcane Brotherhood / Sea-of-Swords pirate axis (and Mintarn).
 - [sword-coast-hansa.md](sword-coast-hansa.md) — the informal Baldur's-Gate-centered regional trade alliance.
+- [waterdeep-government.md](waterdeep-government.md) — Waterdeep's Open Lord, Masked Lords, Blackstaff system.
 - [worshipful-company-system.md](worshipful-company-system.md) — institutional shape of a Worshipful Company (Master / Wardens / Court of Assistants / apprenticeship).

--- a/10-Setting/polities/calimshan-amn.md
+++ b/10-Setting/polities/calimshan-amn.md
@@ -1,0 +1,36 @@
+---
+name: calimshan-amn
+description: The southern powers — Amn and Calimshan — projecting capital, soldiery, and privateers up the coast into Sword Coast affairs.
+---
+
+# Calimshan and Amn
+
+The two great southern powers whose interests bear directly on the Sword Coast. Neither is on the coast in the strict sense; both project upward through banking, contraband, hired pirates, and the foreign Kontor in Baldur's Gate.
+
+## Amn — the disciplined merchant kingdom
+
+Amn is the Sword Coast's *southern* commercial peer to Waterdeep, capital at **Athkatla**, ruled by an oligarchy of trading houses called the **Council of Six**. Its hallmark is procedural rigor: customs in triplicate, manifests in duplicate, bribes accepted on a published schedule. Amn projects three ways into Sword Coast affairs:
+
+- **Through the [Amnian Kontor](../../20-Factions/amnian-kontor/summary.md)** in Baldur's Gate. The **Gold-Gable Hall** is Amnian banking's beachhead; Consul Vorlamin Athar runs it. Amn does not formally join the [Sword Coast Hansa](sword-coast-hansa.md), but every Hansa cross-city contract that needs underwriting passes through Amnian credit.
+- **Through Snowdown.** Amn's garrison and viceroy on the southernmost Moonshae isle. The dossier reports neat fields and neat books; the viceroy's reach extends only as far as Amnian musket-range, but that range is real.
+- **Through letters of marque.** Amn quietly issues licenses to certain Nelanther captains to harass Waterdhavian and Baldurian shipping — provided Amnian hulls go untouched. The relationship is plausible-deniable and enduring.
+
+Amn pushes north on **Nashkel** at the Trade Way border (see [`30-Places/sword-coast/nashkel/`](../../30-Places/sword-coast/nashkel/README.md)) and south against **Tethyr**'s recovering monarchy. The kingdom is stable, well-armed, and patient.
+
+## Calimshan — the empire of spice and slavery
+
+Older and stranger than Amn. Capital **Calimport**; ruled by the **Pasha of Pashas** atop a pyramid of merchant houses, slave-barons, and genie-pact noble lineages. Calimshan exports spices, opals, fine glass, and slaves; imports timber, iron, and northern wool. Three things the Sword Coast notices about Calimshan:
+
+- **The southern terminus of the Sword Coast Run.** Calishite buyers are the price-makers for any high-margin southbound cargo (spices come north, finished goods go south). A captain's ledger lives or dies on Calimport prices.
+- **Slavery is legal there.** The dossier names Skaug as the major fence for slaves taken on Sword Coast waters; the buyers are almost always Calishite. The Lords' Alliance officially opposes the trade and effectively cannot stop it.
+- **Wizardry and genie-binding.** Calimshan retains older magical traditions — efreet-bound, jann-served — that read as exotic in the North. Calishite mages travel light and well-funded; the Hosttower in Luskan is on civil but wary terms with the Pasha's court mages.
+
+## How these two interact
+
+Commercial and territorial rivals south of campaign scope. On Sword Coast questions they often align — both want the Lords' Alliance contained, both profit from Hansa standardization, both tolerate Nelanther piracy. They diverge on Tethyr (Amn wants it weak), Snowdown (Amnian), and the slave trade (Calimshan wants it unmolested).
+
+Treat Amn as **near** (agents, capital, privateers); treat Calimshan as **distant but heavy** (price-making buyers; a Calishite face on the Sword Coast is event-worthy).
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Moonshaes (Snowdown), Nelanther (Skaug fence trade), Trade Routes (sea lanes south).

--- a/10-Setting/polities/lords-alliance.md
+++ b/10-Setting/polities/lords-alliance.md
@@ -1,0 +1,37 @@
+---
+name: lords-alliance
+description: The Lords' Alliance — formal Waterdeep-led mutual-defense and trade pact binding the major Sword Coast North polities.
+---
+
+# The Lords' Alliance
+
+A formal political and military confederation of the Sword Coast North, founded in 1314 DR with Waterdeep as its anchor. The Alliance binds **Waterdeep, Neverwinter, Silverymoon, Mirabar, Yartar**, and a rotating cohort of smaller polities through shared diplomacy, coordinated trade agreements, and mutual defense. Chaired by the **Open Lord of Waterdeep** — currently [Laeral Silverhand](waterdeep-government.md).
+
+## What it is — and isn't
+
+A real chartered confederation, distinct from the informal [Sword Coast Hansa](sword-coast-hansa.md) it overlaps with. The Alliance:
+
+- **Holds the chair from Waterdeep.** The Open Lord coordinates Alliance diplomacy and convenes member representatives. Member cities each retain full sovereignty.
+- **Coordinates fleet patrols.** Member navies — Waterdhavian, Baldur's-Gate-aligned (informally), Neverwinter — patrol the **Sword Coast Run** between major ports, enforce anti-piracy mandates, and project force into contested waters when in concert. The 1498 DR victory at Asavir's Channel that broke Bloodwave's Black Flag Fleet was the Alliance's high-water mark of the decade.
+- **Issues membership as currency.** A seat in the Alliance is the difference between being inside the system that runs the North and being outside it. **Luskan**'s pursuit of a seat — through Jarlaxle Baenre's Bregan D'aerthe brokering — is the live political question of 1502 DR; **Neverember of Neverwinter** opposes it because dilution of his vote is the price.
+
+## What it doesn't do
+
+- **Does not bind Baldur's Gate.** The Gate sits inside the [Hansa](sword-coast-hansa.md) and outside the Alliance; the [Waterdhavian Kontor](../../20-Factions/waterdhavian-kontor/summary.md)'s Splendid Yard is the Alliance's southern embassy and its primary intelligence node into the city.
+- **Does not patrol the southern coast.** Alliance ships work the corridor from Waterdeep south to Orlumbor and occasionally to Candlekeep waters. Below the Nelanther bottleneck, the corridor is Hansa or Calishite turf — see [calimshan-amn.md](calimshan-amn.md).
+- **Does not project inland authority.** The new line of forts Laeral is constructing along the **High Road** is a recent and unprecedented step *toward* Alliance writ beyond the walls; its ambition is exactly the measure of how rare such writ has been.
+
+## Why it works
+
+- **Naval coordination.** Member fleets together suffice to deter casual piracy and win pitched fleet engagements (Asavir's Channel, 1498 DR).
+- **Shared diplomatic posture.** Recognized passports and shared blacklists (notably Zhentarim fronts) mean a member's enforcement decision carries weight in every member harbor.
+- **Selective rivalry suppression.** The Alliance contains Waterdeep–Neverwinter friction rather than fighting it.
+
+## Friction it creates
+
+- **Excludes pirate-broker economies.** Mintarn lost the Waterdeep mercenary contract under Laeral (~1495 DR); the shortfall now shapes the Tyrant's politics — see [luskan-and-the-pirates.md](luskan-and-the-pirates.md).
+- **Cannot police the deep.** Alliance patrols stop where the Kraken Society and Umberlee's clergy begin. Underwater vetoes are not Alliance business.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Trade Routes & Contraband Lanes; Mintarn; Luskan. Cross-checked against `30-Places/sword-coast/waterdeep/neighbors.md`.

--- a/10-Setting/polities/luskan-and-the-pirates.md
+++ b/10-Setting/polities/luskan-and-the-pirates.md
@@ -1,0 +1,38 @@
+---
+name: luskan-and-the-pirates
+description: The Luskan / Arcane Brotherhood / Sea-of-Swords pirate axis — Five High Captains, Hosttower, Nelanther confederations, and Mintarn neutrality.
+---
+
+# Luskan and the Pirate Coast
+
+The political bloc the [Lords' Alliance](lords-alliance.md) cannot integrate and cannot defeat: **Luskan**, the **Arcane Brotherhood**, the **Nelanther pirate confederations**, and the **Tyrant of Mintarn**. None of these is a state in any conventional sense; together they constitute the working order of the Sword Coast's western waters.
+
+## Luskan — five-headed governance
+
+Officially, Luskan is ruled by the **Five High Captains** (Kurth, Baram, Taerl, Suljack, Rethnor), each the head of a "Ship" — a pirate gang turned hereditary fiefdom. Unofficially, the **Arcane Brotherhood** in the **Hosttower of the Arcane** on Cutlass Island arbitrates between Captains in exchange for magical favors. The current Brotherhood archmage is **Cashaan the Red**.
+
+The Captains present a united face to outsiders and wage a silent war among themselves. Captain Kurth's quiet diplomacy with Waterdeep — and rumored interest in a Lords' Alliance seat — is the most consequential intra-bloc intrigue of 1502 DR. Captain Rethnor is rumored to be a proxy for a **Bregan D'aerthe** (drow) backer; Jarlaxle Baenre's hand is in Luskan as much as it is in Waterdeep.
+
+For the city itself see [30-Places/sword-coast/luskan/](../../30-Places/sword-coast/luskan/README.md).
+
+## The Arcane Brotherhood
+
+Wizard order, technically subordinate to the Captains, in practice the senior partner. Its long-term project (per dossier) is something **deep beneath Luskan** — possibly an old Illuskan mythal, possibly Illuskian ruin-magic; it has hired diving crews to fish the harbor for "artifacts." The Brotherhood's exemption from Luskan's nominal anti-magic ordinances marks it as the city's effective sovereign in arcane matters.
+
+## The Nelanther Isles
+
+Pirate archipelago south of the Moonshaes. Consolidated by **Ghorin Bloodwave** in the early 1490s; his Black Flag Fleet broken at **Asavir's Channel** in 1498 DR; body never recovered. Successor: **Admiral Austarl Blackmane** — "Sea King" in all but name. **Skaug** remains the neutral fence-port. Below the captains, Umberlee's clergy collect the **Bitch Queen's tithe**. See [30-Places/sword-coast/nelanther-isles.md](../../30-Places/sword-coast/nelanther-isles.md).
+
+## Mintarn — the broker
+
+A free isle midway between Waterdeep and the Moonshaes, ruled by **Tyrant Bloeth Embuirhan**. Mintarn's golden decade ended when Waterdeep cancelled its mercenary-navy contract (~1495 DR). The Red Rage **Hoondarrh** demands escalating tribute; the Tyrant petitions for Alliance loans and a dragonslayer. Premier neutral parley-ground for the coast. See [30-Places/sword-coast/mintarn/](../../30-Places/sword-coast/mintarn/README.md).
+
+## What this bloc looks like in play
+
+- **A non-Alliance alternative.** Cities that cannot join the Alliance (or do not want to be junior to Waterdeep) trade through Luskan and broker through Mintarn instead.
+- **The Zhentarim's sea arm.** The Black Network operates legitimate fronts in Luskan (the **Red Dragon Trading Post**), Mintarn, and Skaug; sea-borne smuggling is its biggest line of business.
+- **Vulnerable to a single tip.** Three things would unmake the bloc: Luskan's Alliance accession; Hoondarrh's death; the Kraken Society's ambitions surfacing into open war. Any of these is a campaign event.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Luskan, Nelanther, Mintarn chapters.

--- a/10-Setting/regions/README.md
+++ b/10-Setting/regions/README.md
@@ -1,0 +1,14 @@
+---
+name: setting-regions
+description: Region-scale setting matter — bodies of water, mountain ranges, and other macro-geographic features whose *character* matters at the world-fact level.
+---
+
+# Regions
+
+Region-scale setting matter: bodies of water, mountain ranges, and other macro-geographic features whose *character* — currents, weather, who's underneath, what it feels like to cross — matters at the world-fact level.
+
+Specific places with civic identity (cities, ports, named locations) live in [`30-Places/`](../../30-Places/README.md). This folder holds the *region* between and around them.
+
+## Index
+
+- [sea-of-swords.md](sea-of-swords.md) — the Sword Coast's western water; sea-lanes, weather, hazards, the Kraken in the deep.

--- a/10-Setting/regions/sea-of-swords.md
+++ b/10-Setting/regions/sea-of-swords.md
@@ -1,0 +1,46 @@
+---
+name: sea-of-swords
+description: The body of water — sea-lanes, currents, weather, hazards, named features, and the things in the deep that the surface powers cannot reach.
+---
+
+# The Sea of Swords
+
+The western water of the Sword Coast. Bounded on the east by the coast itself from Icewind Dale down through the Sword Coast North, Waterdeep, Baldur's Gate, Amn, and the Tethyrian shore; on the west by the Trackless Sea and the Moonshae Isles. Currents and weather make the sea profitable in summer and lethal in winter; the political map (see [00-Campaign-Frame/multipolar-coast.md](../../00-Campaign-Frame/multipolar-coast.md)) makes it ungoverned year-round.
+
+## Sea lanes
+
+- **The Sword Coast Run.** North–south, hugging the coast from Waterdeep past **Orlumbor** to Baldur's Gate and on to Amn. Lords' Alliance patrols when concerted; otherwise self-protected convoys.
+- **The Western Track.** Open-water route from Baldur's Gate or Athkatla west of the **Nelanther** to the Moonshaes or Luskan. Storm-prone; few friendly ports; a Mintarn or Skaug stopover is common.
+- **The Northern Reach.** Waterdeep north to Neverwinter, Luskan, and Icewind Dale. Short but rocky; winter ice closes it; ice mephits and a young white dragon harassed shipping in 1496–1497 DR.
+- **Asavir's Channel.** The bottleneck through the Nelanther. The Lords' Alliance broke Bloodwave's Black Flag Fleet here in **1498 DR**; it remains the choke point for any concerted southern campaign.
+- **Chionthar–Sea link.** The river meets the sea at Baldur's Gate; smugglers offload upriver to bypass the city's tariffs and re-embark in marshy delta coves.
+
+## Currents and weather
+
+- **Northern Drift** — east-by-southeast, carries westerly-launched hulls toward the mainland within three days.
+- **Alaron Counter** — slow summer set running south along Alaron's lee.
+- **Viper Current** — westbound through the Nelanther; flings unwary keels toward hidden shoals.
+- **Circling Gyre** — sluggish becalming patch in the Nelanther.
+- **Umberlee's Slaps** — sudden squalls out of the Sea of Swords without warning. Tribute and prayer reduce frequency, captains insist.
+- **Devil's Glass** — patches of slick water that signal dead calm; bring sweeps.
+- **Moonfog** — white wool, swallows sound, chases ships onto rocks they hear too late.
+
+## Named features
+
+- **Asavir's Channel** — the Nelanther bottleneck.
+- **Whalebones Isles** — west of the Moonshaes; Emerald Enclave–watched whale grounds; lair of the dragon turtle **Aldracath**.
+- **Skadaurak** — volcanic island north of Mintarn; lair of **Hoondarrh the Red Rage**.
+- **Purple Rocks** — small archipelago northwest of Ruathym; locals worship the **Watcher in the Waves** (Slarkrethel by another name).
+- **Ascarle** — drowned elven city off the Purple Rocks, repurposed as the Kraken's lair; rumored stirring since 1501 DR.
+- **Trackless Sea** — open western water. Whole caravels have vanished here since 1501; sailors blame tentacles vast as towers.
+
+## What lives in the deep
+
+- **The Kraken Society and Slarkrethel.** A surface cabal serving an ancient kraken; agents in Luskan, Gundbarg, even Baldur's Gate. Glyph: skull with kraken-tentacled jaw. See [luskan-and-the-pirates.md](../polities/luskan-and-the-pirates.md).
+- **Umberlee's clergy.** Shrines in every coastal port; the Bitch Queen's tithe is paid by every honest captain.
+- **Sahuagin, sea hags, dragon turtles, ghost ships.** Treated by the dossier as **weather**, not events. See [00-Campaign-Frame/sea-as-frontier.md](../../00-Campaign-Frame/sea-as-frontier.md).
+- **Aboleths and starspawn.** Whispered. The 1499 DR green-comet impact west of Evermeet has correlated with strange lights and unnatural dreams ever since.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Trade Routes; Kraken Society; Monsters of the Deep; passing references throughout.

--- a/20-Factions/amnian-kontor/summary.md
+++ b/20-Factions/amnian-kontor/summary.md
@@ -26,7 +26,13 @@ Staffed entirely by Amnian nationals and led by Consul Vorlamin Athar. The encla
 
 **Enemies.** Quiet financial warfare with the rival Kontors — [Waterdhavian](../waterdhavian-kontor/summary.md), [Sembian](../sembian-kontor/summary.md), [Lantaner](../lantaner-concession/summary.md) — and with the local [Chionthar Consortium](../chionthar-consortium/summary.md) and [Western Gate Trading Company](../western-gate-trading-company/summary.md), who resent their reach.
 
+## At Sword Coast scale
+
+The Kontor is **Amn's beachhead in Baldur's Gate**, not the empire itself. The home polity — capital **Athkatla**, ruled by the Council of Six — is treated as setting matter in [10-Setting/polities/calimshan-amn.md](../../10-Setting/polities/calimshan-amn.md); the Sword-Coast-wide picture is in [00-Campaign-Frame/multipolar-coast.md](../../00-Campaign-Frame/multipolar-coast.md). Amn also occupies **Snowdown** in the Moonshaes (garrison; viceroy; tariff-rigorous quayside) and quietly issues letters of marque to Nelanther captains against Waterdhavian shipping — see [30-Places/sword-coast/moonshae-isles.md](../../30-Places/sword-coast/moonshae-isles.md) and [30-Places/sword-coast/nelanther-isles.md](../../30-Places/sword-coast/nelanther-isles.md).
+
 ## See also
 
 - [Consul Vorlamin Athar](people/vorlamin-athar.md) — leader.
-- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Kantors); cleaned prose in `.context/attachments/pasted_text_2026-04-26_23-30-55.txt`.
+- [10-Setting/polities/calimshan-amn.md](../../10-Setting/polities/calimshan-amn.md) — the Amn polity at home and on the southern Sword Coast.
+- [30-Places/sword-coast/athkatla/](../../30-Places/sword-coast/athkatla/README.md) — anchor for the home capital.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Kantors); `.context/converted/dossier-sea-of-swords.md` (Snowdown, Trade Routes); cleaned prose in `.context/attachments/pasted_text_2026-04-26_23-30-55.txt`.

--- a/20-Factions/harpers/summary.md
+++ b/20-Factions/harpers/summary.md
@@ -37,8 +37,12 @@ The cell uses the [Waterdhavian Kontor](../waterdhavian-kontor/summary.md)'s **S
 
 **Hooks.** A planted agent inside the [Worshipful Company of Masons & Sculptors](../wc-masons-sculptors/summary.md) was identified and turned without his knowledge — fed misinformation by Master Borin Stonehand. Randal Evenwood's attempt to flip a clerk inside Archduke Silvershield's organization was a counter-intelligence trap; he is now burned. A back-channel meeting at the Singing Lute to broker compromise between moderates was leaked and published in a rival pamphlet, discrediting the participants.
 
+## At Sword Coast scale
+
+Harper presence is **continuous along the coast** — pigeon and gull post, sympathetic captains, planted navigators. A Harper brokered the Tethyrian privateer arrival at **Asavir's Channel** (1498 DR) that helped the Alliance break Bloodwave. **Ruathym** is the only closed Northlander isle that tolerates known Harpers. A 1501 DR Harper missive flagged unusual tides at the **Purple Rocks** — possibly Ascarle stirring. See [30-Places/sword-coast/ruathym/](../../30-Places/sword-coast/ruathym/README.md) and [30-Places/sword-coast/purple-rocks.md](../../30-Places/sword-coast/purple-rocks.md).
+
 ## See also
 
 - ["The Nightingale"](people/the-nightingale.md) — cell leader.
 - [Waterdeep — Factions](../../30-Places/sword-coast/waterdeep/factions.md) — the Waterdeep cell's "Wise Owls" (Vescaras Ammakyl, Remallia Haventree) and stance against the Zhentarim.
-- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Societies); `faction-quests.xlsx`; `dossier-waterdeep-1502-dr-a-city-of-veiled-threats.docx`.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Societies); `faction-quests.xlsx`; `dossier-waterdeep-1502-dr-a-city-of-veiled-threats.docx`; `dossier-sea-of-swords.md` (Asavir's Channel; Ruathym; Kraken Society).

--- a/20-Factions/waterdhavian-kontor/summary.md
+++ b/20-Factions/waterdhavian-kontor/summary.md
@@ -25,9 +25,14 @@ Led by Factor Elara Mornwood, a high-ranking half-elf member of the Lords' Allia
 
 **Enemies.** Primary rivals are the expansionist [Amnian Kontor](../amnian-kontor/summary.md) and the criminal Zhentarim network. Tensions also run hot with the [Society of Baldurian Integrity](../society-of-baldurian-integrity/summary.md), who view the Yard as the heart of "memetic" cultural infiltration.
 
+## At Sword Coast scale
+
+The Splendid Yard is the **Lords' Alliance**'s southern embassy and primary intelligence node into Baldur's Gate; the Alliance polity itself is treated as setting matter in [10-Setting/polities/lords-alliance.md](../../10-Setting/polities/lords-alliance.md). Alliance fleet patrols on the **Sword Coast Run** (Waterdeep–Orlumbor–Candlekeep) underwrote the 1498 DR victory at **Asavir's Channel**; Yard logistics support continuing convoys southward as far as the Yard's writ extends. Live political work in 1502 DR centers on the **Luskan accession** play (Bregan D'aerthe brokering) and on Mintarn's quiet petition for an Alliance dragonslayer against Hoondarrh — see [30-Places/sword-coast/luskan/](../../30-Places/sword-coast/luskan/README.md) and [30-Places/sword-coast/mintarn/](../../30-Places/sword-coast/mintarn/README.md).
+
 ## See also
 
 - [Factor Elara Mornwood](people/elara-mornwood.md) — leader.
 - [Waterdeep](../../30-Places/sword-coast/waterdeep/README.md) — home city; the Splendid Yard in Baldur's Gate is the Kontor's southern outpost.
 - [Waterdeep — Government](../../10-Setting/polities/waterdeep-government.md) — the Open Lord chairs the Lords' Alliance whose agenda the Kontor advances.
-- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Kantors); `dossier-waterdeep-1502-dr-a-city-of-veiled-threats.docx`.
+- [Lords' Alliance polity](../../10-Setting/polities/lords-alliance.md) — the regional confederation the Yard projects.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Kantors); `dossier-waterdeep-1502-dr-a-city-of-veiled-threats.docx`; `dossier-sea-of-swords.md` (Trade Routes; Asavir's Channel).

--- a/20-Factions/zhentarim/summary.md
+++ b/20-Factions/zhentarim/summary.md
@@ -31,8 +31,12 @@ The local network is overseen by the cunning trader **Roah Moonglow**. The organ
 
 **Hooks.** The Brampton arson and the Velvet Hand are explicit provocations to Nine-Fingers Keene, intended to draw the Guild into an overreaction. Roah is currently scouting any newly-outlawed adventuring party as potential muscle.
 
+## At Sword Coast scale
+
+The Black Network's largest line of business is **sea-borne smuggling**. In Luskan it fronts the **Red Dragon Trading Post** and runs the city's biggest gunpowder ring; Zhent cutters work the Sword Coast Run with hidden swivels and multiple flag-sets. Mainland-side, agents ferry contraband across the Chionthar to bypass the Gate's inspectors. Bregan D'aerthe and the Hosttower Brotherhood actively contest Zhent influence in Luskan. See [30-Places/sword-coast/luskan/](../../30-Places/sword-coast/luskan/README.md).
+
 ## See also
 
 - [Roah Moonglow](people/roah-moonglow.md) — local director.
 - [Waterdeep — Factions](../../30-Places/sword-coast/waterdeep/factions.md) — the Doom Raiders (Davil Starsong, Skeemo Weirdbottle) vs. Manshoon's clone faction; the Shadow War.
-- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Societies); `faction-quests.xlsx`; `dossier-waterdeep-1502-dr-a-city-of-veiled-threats.docx`.
+- Source: `raw-ingest/cloaks-and-conspiracies/factions.docx` (Public Factions › Societies); `faction-quests.xlsx`; `dossier-waterdeep-1502-dr-a-city-of-veiled-threats.docx`; `dossier-sea-of-swords.md` (Luskan; Trade Routes).

--- a/30-Places/sword-coast/README.md
+++ b/30-Places/sword-coast/README.md
@@ -12,9 +12,20 @@ The **Coast Way** and the **Trade Way** are the great north–south arteries; th
 
 ## Index
 
+### Region-scope files
+
+- [character.md](character.md) — the trade-coast vibe and the splits with inland and deep.
+- [neighbors.md](neighbors.md) — external regions: Moonshaes, Northlander seas, Tethyr/Calimshan, Underdark.
+- [polities.md](polities.md) — short index of regional governing bodies and trade alliances; framework prose lives in [10-Setting/polities/](../../10-Setting/polities/).
+- [demographics.md](demographics.md) — regional ancestry and post-crisis migration patterns.
+
 ### Cities
 
+- [athkatla/](athkatla/README.md) — capital of Amn; southern terminus of the Sword Coast Run.
 - [baldurs-gate/](baldurs-gate/README.md) — the Phoenix on the Chionthar; Hansa head, plutocratic, ten years past the Absolute Crisis.
+- [calimport/](calimport/README.md) — capital of Calimshan; the deep south.
+- [luskan/](luskan/README.md) — five-Captain pirate-city at the mouth of the Mirar; Arcane Brotherhood power.
+- [neverwinter/](neverwinter/README.md) — the Jewel of the North; Lords' Alliance member under Dagult Neverember.
 - [waterdeep/](waterdeep/README.md) — Crown of the North, City of Splendors. Secretive oligarchy and de facto capital of the Lords' Alliance.
 
 ### Settlements
@@ -23,22 +34,28 @@ The **Coast Way** and the **Trade Way** are the great north–south arteries; th
 - [berdusk/](berdusk/README.md) — Western Heartlands city on the upper Chionthar; Harper redoubt under Zhentarim pressure.
 - [boareskyr-bridge/](boareskyr-bridge/README.md) — Trade Way crossing of the River Winding Water, held by Elturgardian paladins.
 - [candlekeep/](candlekeep/README.md) — fortress-library on a promontory over the Sea of Swords.
+- [daggerford/](daggerford/README.md) — small Lords' Alliance town on the High Road south of Waterdeep.
 - [elturel/](elturel/README.md) — city returned from the Nine Hells, slowly rebuilding.
 - [fort-morninglord/](fort-morninglord/README.md) — abandoned Elturgardian fort on the Trade Way.
 - [nashkel/](nashkel/README.md) — border town between the Sword Coast and Amn.
+- [skaug/](skaug/README.md) — neutral pirate haven of the Nelanther Isles.
+
+### Independent islands
+
+- [mintarn/](mintarn/README.md) — the Free Isle for Sale; neutral mercenary-port under Hoondarrh's shadow.
+- [orlumbor/](orlumbor/README.md) — the Forge of the Sea; Lords' Alliance shipwright island.
+- [ruathym/](ruathym/README.md) — Axehome of the Northlanders; closed since 1498 DR.
 
 ### Macro-region features
 
 - [cloakwood.md](cloakwood.md) — vast forest south of Baldur's Gate; Sword Coast timber reserve; fey-real; in active war.
+- [moonshae-isles.md](moonshae-isles.md) — crown-and-fey island chain on the Sea of Swords' northwestern rim.
+- [nelanther-isles.md](nelanther-isles.md) — pirate archipelago south of the Moonshaes.
+- [purple-rocks.md](purple-rocks.md) — small Northlander archipelago northwest of Ruathym; surface settlement, drowned Ascarle below.
 - [wood-of-sharp-teeth.md](wood-of-sharp-teeth.md) — east of the Trade Way; severed from the natural world by the Absolute Crisis; generates psychic horror.
-
-### Region-scope files
-
-- [polities.md](polities.md) — short index of regional governing bodies and trade alliances; framework prose lives in [10-Setting/polities/](../../10-Setting/polities/).
-- [demographics.md](demographics.md) — regional ancestry and post-crisis migration patterns.
 
 ## Neighbors and adjacent dossiers
 
 - South: Amn (Athkatla), Calimshan, the Sembian-influenced trade corridor.
-- West: Sea of Swords (#20 forthcoming).
+- West: [Sea of Swords](../../10-Setting/regions/sea-of-swords.md) (#20).
 - North: Sword Coast North; Neverwinter, Luskan, Icewind Dale.

--- a/30-Places/sword-coast/athkatla/README.md
+++ b/30-Places/sword-coast/athkatla/README.md
@@ -1,0 +1,24 @@
+---
+name: athkatla
+description: Capital of Amn — the disciplined merchant kingdom south of the Sword Coast; counting-house in stone.
+---
+
+# Athkatla
+
+City of Coin — capital of the kingdom of **Amn**, on the southern Sword Coast. Built around the **Athkatla Harbor** and the great walled merchant district; ruled by the **Council of Six**, an oligarchy of trading houses whose membership rotates by wealth and influence.
+
+For Amn as a polity see [10-Setting/polities/calimshan-amn.md](../../../10-Setting/polities/calimshan-amn.md). For Amn's Baldur's Gate beachhead see [20-Factions/amnian-kontor/](../../../20-Factions/amnian-kontor/summary.md).
+
+## What's here
+
+- [character.md](character.md) — discipline, coin, and the smile that ends at the coffer.
+
+## Why it matters
+
+- **Southern terminus of the Sword Coast Run.** Athkatla is where southbound cargoes meet Amnian credit; the Gold-Gable Hall in Baldur's Gate reflects what works here.
+- **The Council of Six.** Amn's ruling oligarchy is opaque; specific membership is held more closely than Waterdeep's Masked Lords. Council decisions on tariffs, letters of marque, and Snowdown deployment shape the entire southern Sword Coast.
+- **Privateer broker.** Amn issues letters of marque to certain Nelanther captains against Waterdhavian shipping. The administrative office for this exists in Athkatla; the practice is plausibly deniable and quietly persistent.
+
+## Notes
+
+A stub. Athkatla is not the focus of the Sea-of-Swords dossier; the campaign sees Amn primarily through its **Kontor** in Baldur's Gate and through its **garrison on Snowdown**. This file anchors regional references.

--- a/30-Places/sword-coast/athkatla/character.md
+++ b/30-Places/sword-coast/athkatla/character.md
@@ -1,0 +1,30 @@
+---
+name: athkatla-character
+description: Counting-house at scale — discipline, paperwork, and the long memory of debt.
+---
+
+# Character
+
+Athkatla is a city the dossier implies more than describes: neat fields and neat books on Snowdown are imitations of the real thing here. The harbor is square-built; the customs house is staffed in three shifts; the manifest is required in duplicate, the bribe accepted in triplicate.
+
+## The trading houses
+
+Six houses dominate; many more aspire. Membership in the Council of Six rotates by coin and connections. The houses share a culture: long memory, written contracts, slow grudges. An Amnian merchant insulted in Athkatla today will write the insult into a private ledger and pay you back with interest in fifteen years.
+
+## Religion and law
+
+State law is procedural. Religion is permitted as long as it pays its dues. The dominant faith is Waukeen (Merchant's Friend); Helm and Tyr are also well-attended. Sumptuary laws apply but are honored only by the unfashionable.
+
+## Useful to whom
+
+- **Captains** running spices, silks, or refined metals south. Amnian buyers are price-makers.
+- **Investigators** with subpoena-style authority — Amnian record-keeping is exhaustive and findable, *if* you have the right writ.
+
+## Avoid
+
+- Joking about taxes where a quill can hear you.
+- Any pitch that requires the Council of Six to act *fast*. They will not.
+
+## Source
+
+This stub draws on `.context/converted/dossier-sea-of-swords.md` (Snowdown's Amnian discipline as a stand-in for Athkatla's character; passing references in Trade Routes). Treat as anchor pending dedicated Amn ingest.

--- a/30-Places/sword-coast/calimport/README.md
+++ b/30-Places/sword-coast/calimport/README.md
@@ -1,0 +1,24 @@
+---
+name: calimport
+description: Capital of Calimshan — the deep south, terminus of the Sword Coast Run, and the empire of spice and slavery.
+---
+
+# Calimport
+
+Largest city on the southern Sword Coast and capital of the kingdom of **Calimshan**. Spices, opals, fine glass, slaves, and ancient genie-bound magical traditions; the **Pasha of Pashas** rules atop a pyramid of merchant houses and slave-baron lineages.
+
+For Calimshan as a polity see [10-Setting/polities/calimshan-amn.md](../../../10-Setting/polities/calimshan-amn.md).
+
+## What's here
+
+- [character.md](character.md) — the southern terminus and what arrives there.
+
+## Why it matters
+
+- **Southern terminus of the Sword Coast Run.** Calishite buyers are the price-makers for high-margin southbound cargo: spices come north, finished goods (timber, iron, wool, glass) go south. A captain's southern leg lives or dies on Calimport prices.
+- **The slave market.** Slavery is legal in Calimshan; Skaug fences captives taken on Sword Coast waters here. The Lords' Alliance officially opposes the trade and effectively cannot stop it.
+- **The genie tradition.** Calishite mages bind efreet and serve jann; this magical posture is older and stranger than any northern wizard tradition. The Hosttower in Luskan keeps civil but careful relations with the Pasha's court mages.
+
+## Notes
+
+A stub. Calimport is not a focus of the Sea-of-Swords dossier — it appears as the **distant heavy** end of the southern trade. This file is an anchor; a dedicated Calimshan ingest can come later.

--- a/30-Places/sword-coast/calimport/character.md
+++ b/30-Places/sword-coast/calimport/character.md
@@ -1,0 +1,27 @@
+---
+name: calimport-character
+description: Old, hot, and stratified — the south.
+---
+
+# Character
+
+A city the dossier touches only obliquely. From Sword Coast captains' perspective, Calimport is the **buyer**: the place where a hold of bone-carving from Norland fetches foolish coin, where Sembian wool finds Calishite tailors, where a chest of Calishite opals already smells of someone else's blood. The taverns of Skaug and Luskan are full of Calimport prices.
+
+## What's true at Sword Coast remove
+
+- The city is **vast** — the largest port on the southern coast.
+- Slavery is legal and visible.
+- Magical practice is more old-empire than mainland; a Calishite mage on the Sword Coast carries a reputation for binding things.
+- The Pasha of Pashas does not concern himself with Sword Coast affairs directly; his regents and trading-house factors carry that weight.
+
+## Useful to whom
+
+- **Captains running south** — Calimport is the destination, not the stopover. Plan for the round trip.
+
+## Avoid
+
+- Any framing that treats Calimshan as a single actor. The kingdom is older and more fractured than the unified facade it presents to outsiders.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Trade Routes; Skaug fence references. A dedicated Calimport / Calimshan dossier is not in the current ingest queue.

--- a/30-Places/sword-coast/character.md
+++ b/30-Places/sword-coast/character.md
@@ -1,0 +1,32 @@
+---
+name: sword-coast-character
+description: The regional vibe — a trade-coast culture welded by the Sea of Swords, fractured by polity, and lived through the working captains and dockhands who treat the water as infrastructure.
+---
+
+# Character
+
+The Sword Coast is not one place. The string of cities running from Luskan down through Waterdeep, Baldur's Gate, Athkatla, and on to Calimport is bound together less by shared rule than by shared **water** — the Sea of Swords carries cargo, gossip, refugees, and pirate flags in roughly equal measure, and every coastal city's character is shaped by what arrives off it.
+
+## The trade-coast vibe
+
+The dominant note is **commercial pragmatism**. Every walled city earns its keep off ship-traffic; every walled city has a customs officer at the quay, a Worshipful Company at the chandlery, and a foreign Kontor or its equivalent in the merchant district. The Lords' Alliance polity in the north and the Sword Coast Hansa in the south are different paint on the same machinery: standardized weights, recognized contracts, brokered tariffs.
+
+Underneath the merchants is a working class of **sailors and dockhands** whose loyalty is to the next berth and the next contract — a Mintarn captain's hire today, a Baldurian convoy's escort tomorrow. The Waterdeep–Baldur's Gate "artisan drain" the Waterdhavian dossier names is one symptom of this: skilled labor moves to where the work is.
+
+## The split with the inland
+
+The character of the **coast** differs sharply from the character of the **inland Western Heartlands** — see [00-Campaign-Frame/frontier-logic.md](../../00-Campaign-Frame/frontier-logic.md). On the coast, money and law have somewhere to live (the customs house, the Hansa court, the Kontor enclave). Step a day's ride east of Baldur's Gate or south of Waterdeep and the institutions thin out. The campaign's two great frontier zones — the Cloakwood and the Wood of Sharp Teeth — are inland and behave by different rules.
+
+## The split with the deep
+
+The other split is downward. Above water, the surface powers fight the surface fights: Alliance versus Hansa, Hansa versus pirates, pirates versus the Bitch Queen's tithe-collectors. Below water, **Umberlee's clergy** and the **Kraken Society** hold vetoes that no surface fleet can break. Every captain pays both. See [00-Campaign-Frame/sea-as-frontier.md](../../00-Campaign-Frame/sea-as-frontier.md).
+
+## Mood in 1502 DR
+
+Cautious prosperity. Ten years from the Absolute Crisis the coast is **richer than in a generation** — Baldur's Gate's reconstruction, the Alliance's Asavir's Channel victory (1498 DR), Hansa tariff-standardization. Gains are uneven: Kontor enclaves prosper, Outer City refugees and rural Hansa towns (Beregost, Nashkel) do not. The Pox Plague in southern ports is the year's dark register.
+
+Three open questions will set the next decade: **Luskan's Alliance accession**, **Hoondarrh's fate over Mintarn**, **Ascarle's rise off the Purple Rocks**. Each is a campaign event waiting to break.
+
+## Source
+
+Distilled from `.context/converted/dossier-sea-of-swords.md` (closing thoughts; trade-routes chapter) and the Baldur's Gate / Waterdeep dossiers' city-side framing.

--- a/30-Places/sword-coast/daggerford/README.md
+++ b/30-Places/sword-coast/daggerford/README.md
@@ -1,0 +1,22 @@
+---
+name: daggerford
+description: Small Lords' Alliance town on the High Road south of Waterdeep; eastern node of the Hansa belt.
+---
+
+# Daggerford
+
+Small market town on the **High Road** about a hundred miles south of Waterdeep, where the road crosses the **River Delimbiyr**. Long held by the Duke of Daggerford as a Lords' Alliance member through Waterdeep; Daggerford's importance is logistical rather than political.
+
+## What's here
+
+- [character.md](character.md) — the country town between two trade systems.
+
+## Why it matters
+
+- **Hansa-Alliance hinge.** Daggerford is the southernmost Lords' Alliance node and the northernmost town in regular contact with Baldur's Gate's [Sword Coast Hansa](../../../10-Setting/polities/sword-coast-hansa.md). Hansa tariffs and Alliance courtesies meet here.
+- **High Road logistics.** Laeral's new line of forts on the High Road runs through Daggerford's territory; the town benefits from increased traffic and patrol presence but also resents Waterdhavian projection.
+- **Caravan stop.** Reasonable inn, ferry across the Delimbiyr, market days. Most travelers north or south spend a night here.
+
+## Notes
+
+A stub. Daggerford is not a focus of the Sea-of-Swords dossier; this anchor exists so the regional README and northbound caravan references resolve. A dedicated Daggerford treatment can come from a future ingest.

--- a/30-Places/sword-coast/daggerford/character.md
+++ b/30-Places/sword-coast/daggerford/character.md
@@ -1,0 +1,25 @@
+---
+name: daggerford-character
+description: Country town on the High Road — Hansa-Alliance hinge with a working market and not much drama.
+---
+
+# Character
+
+A walled market town with a single ducal keep, a covered market, two reasonable inns, and a working ferry. The country around is wheat, sheep, and a thin strip of orchard. After Waterdeep's bustle and Baldur's Gate's reconstruction frenzy, Daggerford reads as **quiet** — the kind of quiet that comes from being on the edge of bigger people's plans.
+
+## Politics
+
+The Duke of Daggerford holds an Alliance seat by inheritance and by Waterdeep's continued tolerance. He governs lightly. The town council is dominated by long-tenure burghers who care more about the ferry rates and the inn licenses than about Alliance debates. Hansa-aligned merchants pass through without friction.
+
+## Mood in 1502 DR
+
+Working. The High Road forts project north (toward Waterdeep) and south (eventually toward Baldur's Gate); Daggerford merchants notice the increased patrol traffic but are not prosperous from it. Refugees from Elturel passed through here a decade ago on their way south to the Outer City, leaving only a handful of permanent residents.
+
+## Useful to whom
+
+- **Couriers north or south** — overnight stop with reasonable security.
+- **Caravan masters** — last serious provisioning before either Waterdeep or the long stretch south.
+
+## Source
+
+This stub is anchored from `.context/converted/dossier-sea-of-swords.md` (Trade Routes; named in the issue acceptance criteria) and the existing Hansa framing.

--- a/30-Places/sword-coast/luskan/README.md
+++ b/30-Places/sword-coast/luskan/README.md
@@ -1,0 +1,32 @@
+---
+name: luskan
+description: City of Sails at the mouth of the Mirar; ruled by Five High Captains and the Arcane Brotherhood; the Sword Coast's northern pirate-port and Lords' Alliance non-member.
+---
+
+# Luskan
+
+City at the mouth of the **River Mirar**, spanning both banks and incorporating five small islands in the harbor. **Cutlass Island** holds the **Hosttower of the Arcane**, home of the **Arcane Brotherhood** that effectively rules the city behind the Five High Captains' fiefdoms.
+
+For the polity-level shape — High Captains, Brotherhood, Kraken Society contention, Bregan D'aerthe — see [10-Setting/polities/luskan-and-the-pirates.md](../../../10-Setting/polities/luskan-and-the-pirates.md).
+
+## What's here
+
+- [character.md](character.md) — the harbor in two faces, the dockside reality, the shadow war.
+
+## Why it matters
+
+Luskan is the **non-Alliance northern terminus** of the Sword Coast Run. Three things make it consequential in 1502 DR:
+
+1. **The Alliance accession question.** Captain **Kurth** is rumored to want a Lords' Alliance seat; **Jarlaxle Baenre** of [Bregan D'aerthe](../waterdeep/factions.md) is brokering it, intending to use Vault-of-Dragons gold to buy it. Approval would re-balance Alliance voting against Neverwinter and would kick the entire pirate-coast bloc.
+2. **The Brotherhood's deep project.** Cashaan the Red and his archmages have hired diving crews to fish Luskan harbor for "artifacts." The dossier suspects an old Illuskan mythal beneath the city. Whatever surfaces will not stay local.
+3. **Kraken Society infiltration.** Tentacle-glyph marks have appeared on Luskan pilings; the **Wave Mother's Hall** (temple of Umberlee on the seaside) may have a Kraken priest in residence. The Brotherhood hunts these cultists when found, but a Brotherhood mage was domination-ed by "sea whispers" last year and nearly summoned something in the harbor.
+
+## Players in Luskan
+
+- **Five High Captains** — Kurth, Baram, Taerl, Suljack, Rethnor. Open-Shore docks vs Whitesails Harbor; Ship-coloured patrols; murder ignored unless it disrupts business.
+- **Arcane Brotherhood** — Hosttower-based; **Cashaan the Red**; effective senior partner in city governance.
+- **Kraken Society** — covert; tentacle-glyph; recruits dockhands and warehouse-keepers.
+- **[Zhentarim](../../../20-Factions/zhentarim/summary.md)** — operate the **Red Dragon Trading Post** as front; Luskan's biggest illicit gunpowder ring.
+- **Bregan D'aerthe** — drow mercenary company; running interference against Zhent and Kraken alike; pursuing the Alliance accession play.
+- **[Harpers](../../../20-Factions/harpers/summary.md)** — at least one informer in residence; tracking Kraken Society moves.
+- **Hellraiser ghost ship**, the **Eye of the Deep** sapphire, the **Illuskan Ghost** — local color, possible adventure hooks.

--- a/30-Places/sword-coast/luskan/character.md
+++ b/30-Places/sword-coast/luskan/character.md
@@ -1,0 +1,53 @@
+---
+name: luskan-character
+description: City of Sails in shadow — the two-faced harbor, the Ship-coloured patrols, and a city where the shadows have sharp blades.
+---
+
+# Character
+
+Luskan smells of cold salt and rope-tar; the wind is always running down the Mirar from the inland snows, and the harbor never quite warms. The city wears a respectable coat now — thread-bare, stolen — over the same pirate bones it has always had.
+
+## Two harbors
+
+The harbor has two faces. **Whitesails Harbor**, inside the walls and behind the boom nets, is for Luskan's own ships and certified allies; everyone else moors at the **Open Shore** outside the city walls and rows in by longboat. The Harbormaster (one Captain Deggs, scarred old corsair) runs the dock-fee racket on the Open Shore; a few extra coins ensure your hull is not "accidentally" set adrift while you're ashore.
+
+Approach is shoaly and unmarked; use a local pilot or count on losing a keel.
+
+## Five Ships, five colors
+
+There is no city watch. Each High Captain's crew patrols their own turf in their own colors:
+
+- **Ship Kurth** — black leather; north bank and Closeguard Island; protects the major trade streets.
+- **Ship Taerl** — white wolf graffiti; south bank east.
+- **Ship Baram** — red axe graffiti; south bank west.
+- **Ship Suljack, Ship Rethnor** — outer wards and harbor-island holdings.
+
+Murder is technically illegal and almost always ignored unless it disrupts business or kills someone important. **Magic** is also technically illegal — except for the Brotherhood, who are exempt; openly cast as a nobody and a Hosttower mage or one of their gargoyle servitors will pay a visit.
+
+## Markets and contraband
+
+Luskan is the gateway to the **Silver Marches**. Caravans down from Mirabar end here; Luskan ships carry out Mirabar's ores and gems, scrimshaw from Icewind Dale, ivory tusks, furs, whale oil. Imports: wine, spices, timber, sometimes whole hulls built in Orlumbor for Luskan captains.
+
+A Captains' Court license is required to set up a stall. **Smuggling is rampant** — the [Zhentarim](../../../20-Factions/zhentarim/summary.md) maintain warehouse-tunnels under the docks for night-runs onto the river.
+
+## Work for an outsider
+
+Plenty of "black work": guarding a ship full of contraband to Neverwinter; muscle for a High Captain's raid on a rival's warehouse; hunting someone who crossed the Brotherhood. Pay is good; turnaround is short and often deadly. Trust is the rarest currency — anyone hiring you is also watching you.
+
+## Avoid
+
+- **Rat Alley** in the south bank — local legend says an oni eats lone drunks.
+- **Prisoners' Carnival** square — public executions; usually political theater.
+- **Ruins of Illusk** below the city — undead and worse; many who go in do not return.
+- Open inquiries about the **Eye of the Deep** sapphire — three crews and twenty men died fighting over it last year.
+
+## Useful to whom
+
+- Smugglers with serious cargo and the Captain-Court bribery budget.
+- Mercenaries willing to take Brotherhood contracts and survive the consequences.
+- Harpers and Bregan D'aerthe agents working the Kraken Society and Manshoon plays.
+- Captains running Mirabar ore who can stomach the Open Shore fees.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Luskan chapter; Trade Routes; Kraken Society.

--- a/30-Places/sword-coast/mintarn/README.md
+++ b/30-Places/sword-coast/mintarn/README.md
@@ -1,0 +1,29 @@
+---
+name: mintarn
+description: The Free Isle for Sale — neutral mercenary-port between Waterdeep and the Moonshaes; ruled by Tyrant Bloeth Embuirhan under Hoondarrh's shadow.
+---
+
+# Mintarn
+
+Lush green island with a single jagged peak — **Mount Mintarn** — roughly midway between Waterdeep and the Moonshaes. To the north across a narrow strait looms **Skadaurak**, the volcanic island that lairs **Hoondarrh the Red Rage**.
+
+Mintarn is the **Sword Coast's premier neutral parley-ground**: an island whose ruling Tyrants have for centuries kept peace by renting soldiers and ships to mainland powers and admitting nobody's faction wholesale. It is also, in 1502 DR, an island in trouble.
+
+## What's here
+
+- [character.md](character.md) — Port Mintarn, the Tyrant's court, and Hoondarrh's shadow.
+
+## Why it matters
+
+- **The neutral broker.** Mintarn hosts clandestine meetings the bigger cities cannot host inside their own walls. Baldur's Gate–Amn parleys, secret Alliance–Northlander negotiations, even the Kurth–Ruathym contact that may revive the old Captains' Alliance — all of these run through Mintarn.
+- **The Tyrant's bind.** **Bloeth Embuirhan** (dragonborn, descended from Tarnheel) lost the lucrative Waterdeep mercenary contract when Laeral cancelled it (~1495 DR). Hoondarrh demands escalating tribute. The Tyrant has petitioned the Lords' Alliance for *loans* — coin and a dragonslayer.
+- **The Ashen Wrack.** Secret society of Mintarn citizens dedicated to killing Hoondarrh. Whether the Tyrant encourages them or plans to betray them to the dragon is anyone's guess.
+
+## Players around Mintarn
+
+- **Tyrant Bloeth Embuirhan** — absolute ruler; quietly buying dragon-slaying lore and approaching unsavory powers.
+- **Swords of Mintarn** and **White Sails Company** — the two surviving mercenary outfits; diminished from the golden years.
+- **Hoondarrh the Red Rage** — red dragon on Skadaurak; demands annual tribute barge; toppled two towers of Castle Mintarn in 1498 DR.
+- **The Ashen Wrack** — covert dragon-slaying society.
+- **Foreign observers** — Waterdhavian, Neverwinterite, Amnian, Baldurian, Zhentarim. Spy on each other in Mintarn's taverns.
+- **Hoondarrh's mate or offspring** — rumored awakened under Mount Mintarn (1500 DR); ground tremors at night.

--- a/30-Places/sword-coast/mintarn/character.md
+++ b/30-Places/sword-coast/mintarn/character.md
@@ -1,0 +1,42 @@
+---
+name: mintarn-character
+description: Free port and broker-isle — the Iron Courtyard, the Tyrant's tired smile, and a dragon's tribute always coming due.
+---
+
+# Character
+
+Approach Mintarn from the south and you see the **Queen's Crown** — a ring of standing megaliths marking the safe approach to the deep harbor on the island's south side. Keep them evenly to port and starboard; submerged rocks claim careless keels. The harbor itself is calm, the kind of calm sailors joke is the dragon's way of lulling victims.
+
+## The Free Port
+
+Port Mintarn is built around the **Iron Courtyard**, the dockside market square where bloodshed is the one inviolate offense — to keep trade flowing. Duels and brawls happen on the beaches at dawn instead. The harbormaster (a half-elf named Safael) charges a flat 1 gp per mast per week with no questions about cargo. Military-looking ships pay an additional ~50 gp "security fee" in case local toughs would otherwise trouble them.
+
+The Tyrant's **Peacekeepers** patrol in light blue tabards. They care about open street murder or theft and about little else.
+
+## What you can buy here
+
+- **Trained mercenaries** — Swords of Mintarn and White Sails Company. Their loyalty lasts the contract; their skills are real.
+- **Sloops and small cutters** — Mintarn shipwrights are good and fast.
+- **Whisky and barley ale** — local; an acquired taste involving goat's milk.
+- **Information** — Mintarn's spymaster operates discreetly, the Tyrant herself often on the receiving end. Discreet meetings can be brokered for a "hosting fee."
+
+## What you can do here
+
+- **Take a tribute-barge escort** north to Skadaurak. (Useless work; Hoondarrh takes the gold regardless. Hire pays anyway.)
+- **Run weapons** south for the Tyrant. (Calimshan-bound usually; deniable.)
+- **Sign on as caravan muscle** for VIPs running secret parleys.
+
+## Mood in 1502 DR
+
+Tired. The dossier author saw fatigue in the Tyrant's eyes; he was not wrong. Mintarn's golden years (1480s–early 1490s) ended in a one-two punch: Laeral cancelled the Waterdeep contract, and Hoondarrh attacked **Castle Mintarn** in 1498 DR, toppling two towers. Recruitment is at a low ebb because too many fear the dragon's wrath to sign mercenary contracts as they once did.
+
+A hard rain is going to fall. The shape of it depends on whether the **Ashen Wrack** finds a way to kill Hoondarrh, whether the Lords' Alliance lends a dragonslayer, or whether Mintarn's quiet outreach to Kraken priests yields something other than disaster.
+
+## Avoid
+
+- Speaking carelessly in tavern about contract values, Alliance routes, or anyone's plans for Skadaurak. The walls hire ears.
+- Refusing the Tyrant a hosting fee for a parley. She does not refuse twice; she remembers.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Mintarn chapter (Tyrant's court, harbor procedure, decade of recent years, Hoondarrh's tribute).

--- a/30-Places/sword-coast/moonshae-isles.md
+++ b/30-Places/sword-coast/moonshae-isles.md
@@ -1,0 +1,49 @@
+---
+name: moonshae-isles
+description: Crown-and-fey island chain on the Sea of Swords' northwestern rim — Alaron, Gwynneth, the Northlander Isles, Amnian Snowdown.
+---
+
+# The Moonshae Isles
+
+Green-and-fog island chain on the northwestern Sea of Swords. Four hands pull the Isles in four directions:
+
+- **Alaron** — High King **Derid Kendrick** at **Caer Callidyrr**; Callidyrr Dragoons in green and bronze; the strongest mortal authority on the Isles, on a shrinking budget.
+- **Gwynneth** under **Sarifal** — eladrin High Lady **Ordalf**; mortal law is a guest at best. *Never bargain on the full moon. Never thank an eladrin.*
+- **The Northlander Isles** (Norland, Oman, Moray) — under the **Storm Maiden** at **Frostfall Hall**; raid-right and feud; spear and oath the operating order.
+- **Snowdown** — Amnian garrison and viceroy; neat fields, neat books, neat graves. *Customs first, courtesy later.*
+
+## Currents and harbors
+
+Currents and named hazards (Northern Drift, Alaron Counter, Devil's Glass, Moonfog, Bent Compass in Sarifal's lee) are catalogued in [10-Setting/regions/sea-of-swords.md](../../10-Setting/regions/sea-of-swords.md). Major Moonshae harbors:
+
+- **Caer Callidyrr** (Alaron) — mud/stone bottom; timber runs and guard billets; Zhent buyers and a court that smiles with teeth.
+- **Northpoint** (Alaron) — sand/kelp; fish runs; fog that eats distance.
+- **Fairharbor** (Alaron) — shingle; flax and barrel-staves; bailiff's fees, dockside knives.
+- **Maerwatch** (Alaron) — smuggler cliff cove; aim between The Bishop's Fingers on falling tide.
+- **Salthaven** (Norland) — kelp beds; iron fittings, "discreet" exchanges; dawn duels.
+- **Bear's Back** (Oman) — sand; fur and rare ambergris; sunset surge.
+- **Snowdown Quay** — piled stone, all-round shelter; anything with paper to prove it.
+
+## Sailing rules to live by
+
+- **Tithes and taboos in Sarifal** — pay the **Lady's Share** (a seventh of cargo at low tide); never thank an eladrin; never eat what is offered unless you know the giver's true name; never promise on a moonlit road.
+- **Northlander courtesies** — stand to be measured; suffer boasts; refuse a second horn with a kiss to the rim and a promise to drink the third tomorrow.
+- **Amn's discipline** — manifest in duplicate; bribe in triplicate; do not joke about taxes within a quill's hearing.
+- **Reaver weather** — a low black line at noon means longships under it by dusk. Reef and run, do not out-tack men born to it.
+
+## Recent decade (1492–1502 DR)
+
+- **1492–1494** — Storm Maiden rises; Sarifal's moonwells deepen their silence.
+- **1496** — Callidyrr's coin thins; reavers test every cove.
+- **1498** — Mainland fleets break the big pirate banners (see [40-Timeline/history.md](../../40-Timeline/history.md) on Asavir's Channel); small Northlander flags multiply.
+- **1500** — A night of three moons seen over Gwynneth by twenty crews. All swore never to speak of it; all did.
+- **1502** — Pox in Snowdown's barracks; reavers raiding with storm at their backs; a green flame in a well near Maerwatch.
+
+## See also
+
+- [10-Setting/polities/calimshan-amn.md](../../10-Setting/polities/calimshan-amn.md) — Amn's hold on Snowdown.
+- [10-Setting/regions/sea-of-swords.md](../../10-Setting/regions/sea-of-swords.md) — wider sea.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Moonshae Isles chapter.

--- a/30-Places/sword-coast/neighbors.md
+++ b/30-Places/sword-coast/neighbors.md
@@ -1,0 +1,44 @@
+---
+name: sword-coast-neighbors
+description: External regions bordering the Sword Coast — Moonshae Isles, Northlander seas, Tethyr/Calimshan southward, the Underdark below.
+---
+
+# Neighbors
+
+The Sword Coast is bounded by water on the west, by the Cloud Peaks on the south-east, by the Spine of the World far to the north, and by the Western Heartlands inland. Each border opens onto a distinct neighbor whose politics bear on coastal affairs.
+
+## West — across the Sea of Swords
+
+- **Moonshae Isles.** Crown-and-fey island chain on the Sea of Swords' northwestern rim. Four powers split it: **Alaron** under King Derid Kendrick, **Gwynneth** under the eladrin High Lady Ordalf at **Sarifal**, the **Northlander Isles** (Norland, Oman, Moray) under the **Storm Maiden**, and **Snowdown** under Amnian occupation. See [moonshae-isles.md](moonshae-isles.md).
+- **Nelanther Isles.** Pirate archipelago south of the Moonshaes. **Skaug** is the neutral fence-port; **Admiral Austarl Blackmane** is the post-Bloodwave Sea King. See [nelanther-isles.md](nelanther-isles.md).
+- **Mintarn, Orlumbor, Ruathym.** Independent islands midway out — a broker, a shipyard, and an isolationist Northlander stronghold respectively. See [mintarn/](mintarn/README.md), [orlumbor/](orlumbor/README.md), [ruathym/](ruathym/README.md).
+- **Trackless Sea and the Purple Rocks.** Open western water; Slarkrethel's domain. See [purple-rocks.md](purple-rocks.md).
+
+## North — Sword Coast North and beyond
+
+- **Luskan.** Five-Captain pirate-city at the mouth of the Mirar; Arcane Brotherhood power. See [luskan/](luskan/README.md).
+- **Neverwinter.** Held by **Dagult Neverember** since his ouster from Waterdeep ~1489 DR; sitting Lords' Alliance member. See [neverwinter/](neverwinter/README.md).
+- **Icewind Dale, Mirabar, Silverymoon, Yartar.** Inland Sword Coast North. Mirabar's ores travel to the coast through Luskan; Silverymoon and Yartar route diplomatic traffic through Waterdeep.
+- **Spine of the World.** The northern mountain wall. Beyond it, the Frozen Sea and Northlander territory.
+
+## South — Amn, Tethyr, Calimshan
+
+- **Daggerford and the Hansa belt.** Daggerford is the southernmost Lords' Alliance node; Beregost, Nashkel, and Berdusk are Hansa-aligned smaller polities. See [daggerford/](daggerford/README.md), [beregost/](beregost/README.md), [berdusk/](berdusk/README.md), [nashkel/](nashkel/README.md).
+- **Amn.** Capital **Athkatla**; the southern commercial peer to Waterdeep. See [athkatla/](athkatla/README.md) and [10-Setting/polities/calimshan-amn.md](../../10-Setting/polities/calimshan-amn.md).
+- **Tethyr.** Recovering monarchy south of Amn; mostly out of frame, but Tethyrian privateers (Harper-aligned) have been a wild card in past Alliance fleet actions.
+- **Calimshan.** Capital **Calimport**; the deep south, end of the Sword Coast Run. See [calimport/](calimport/README.md).
+
+## East — the Western Heartlands
+
+The inland zone: caravan routes east of the **Trade Way** and the **Coast Way**, drained by the Chionthar through Baldur's Gate and by the Delimbiyr through the High Forest. The Heartlands are the campaign's archetypal frontier; see [`baldurs-gate/hinterlands/`](baldurs-gate/hinterlands/README.md) and [00-Campaign-Frame/frontier-logic.md](../../00-Campaign-Frame/frontier-logic.md).
+
+## Below — the Underdark
+
+Mentioned for completeness. The Underdark surfaces at scattered points along the coast — most consequentially under **Luskan** (Ruins of Illusk) and beneath **Waterdeep** (the **Xanathar Guild** and the underbelly of the Shadow War). **Bregan D'aerthe** moves between the Underdark and the surface as a matter of course.
+
+## Adjacent dossiers
+
+- **#19 Baldur's Gate** — the Phoenix on the Chionthar.
+- **#21 Waterdeep** — the Crown of the North.
+- **#23 Hinterlands** — the inland zone east of the city walls.
+- **Fey Courts (#22)** — the Green Masquerade and the Court of Stars.

--- a/30-Places/sword-coast/nelanther-isles.md
+++ b/30-Places/sword-coast/nelanther-isles.md
@@ -1,0 +1,44 @@
+---
+name: nelanther-isles
+description: Pirate archipelago south of the Moonshaes — once Bloodwave's, now Blackmane's, neutral ground at Skaug.
+---
+
+# The Nelanther Isles
+
+Pirate archipelago between the Moonshaes and Tethyr's coast. A maze of rock and reef; treasure-laden wrecks stud the seafloor; the currents are tricksters.
+
+For the polity-level shape (Bloodwave-to-Blackmane succession, the Sea King title, the Umberlee tithe) see [10-Setting/polities/luskan-and-the-pirates.md](../../10-Setting/polities/luskan-and-the-pirates.md). For the working fence-port see [skaug/](skaug/README.md).
+
+## The water
+
+- **Viper Current** — westbound; flings unwary keels into hidden shoals.
+- **Circling Gyre** — sluggish becalming patch; ships spin for days under cruel sun.
+- **Asavir's Channel** — the bottleneck through which Sword Coast Run shipping must funnel. The **Lords' Alliance broke Bloodwave's Black Flag Fleet here in 1498 DR**; the channel remains the choke point for any concerted southern fleet action.
+- **Umberlee's Slaps** — sudden squalls out of the Sea of Swords; pay the tithe.
+
+## Politics
+
+Bloodwave consolidated the Isles into the **Black Flag Fleet** in the early 1490s, calling himself Pirate King; he was broken at Asavir's Channel in 1498 DR. Body never found. **Admiral Austarl Blackmane** rose from the wreckage with an Illuskan flagship (the *Brine Hydra*) and a chained pet hydra; he is "Sea King" in all but name. Smaller captains scrap at the margins.
+
+Below the captains the **Umberlee clergy** taxes every hull; refusal of the **Bitch Queen's tithe** correlates with sudden squalls. The **Kraken Society** has agents in the warehouses and on certain vessels; wise captains do not investigate.
+
+## Seamarks
+
+- **Reef-sign:** green water ahead means shallow death. Watch for **frigatebirds**; if they land on water and not rocks, there's a safe channel through.
+- **False flags:** treat any unfamiliar banner as black by default beyond civilized coast-sight.
+- **Parley flag:** white flag below a cask hung from the yardarm. Honored about as often as betrayed.
+- **Red banner:** "no quarter given." Surrender will not save you.
+- **Green lantern at prow** (smugglers): meeting set at next new moon in a hidden cove.
+- **Dead Man's Doubloon:** find a gold coin on deck at dawn, somebody aboard is marked. Tradition: throw the coin overboard with a prayer to Umberlee, fast.
+
+## Recent decade
+
+- **1492–1494** — Bloodwave unites pirates; "Pirate King" rumors fill Skaug taverns.
+- **1496** — Lords' Alliance forces push into the Isles; many pirate dens burn; Mintarn captains play both sides.
+- **1498** — Asavir's Channel; Bloodwave broken; Blackmane rises in the chaos.
+- **1501** — A ghost hulk drifts through the archipelago (lost Amnian caravel). Blackmane forbids boarding; one foolhardy crew that tried was found dead with lungs full of saltwater on a dry ship.
+- **1502** — Blackmane sinks two Amnian frigates in open battle; even he avoids the northern Isles near the **Purple Rocks**, where something older than pirates is waking.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Nelanther Isles chapter.

--- a/30-Places/sword-coast/neverwinter/README.md
+++ b/30-Places/sword-coast/neverwinter/README.md
@@ -1,0 +1,33 @@
+---
+name: neverwinter
+description: The Jewel of the North; rebuilt Lords' Alliance city held by Dagult Neverember since his ouster from Waterdeep.
+---
+
+# Neverwinter
+
+City on the north bank of the **Neverwinter River**, on the Sword Coast North between Waterdeep and Luskan. Famed before the eruption of **Mount Hotenow** (1451 DR) as the **Jewel of the North**; rebuilt over the last half-century, now a working Lords' Alliance member port.
+
+## What's here
+
+- [character.md](character.md) — the rebuilt city under Neverember, and the bad blood with Waterdeep.
+
+## Why it matters
+
+Neverwinter is held by **Dagult Neverember**, the former Open Lord of Waterdeep ousted around 1489 DR for corruption. He retained his Alliance vote through Neverwinter and has been steadily rebuilding the city as a personal power-base — and a counterweight to Waterdeep — ever since.
+
+Three reasons it matters in 1502 DR:
+
+1. **The Alliance balance.** Neverember is the loudest Alliance voice opposing **Luskan**'s accession (see [luskan/](../luskan/README.md)) — because Luskan would dilute his vote and could ally with Waterdeep against him.
+2. **The Mintarn ledger.** Neverember invested heavily in **Mintarn** mercenaries during his Waterdeep tenure; those contracts ended when Laeral cancelled them. The Tyrant of Mintarn still remembers his coin.
+3. **The High Road forts.** Laeral's new line of forts on the High Road runs north toward Neverwinter; this is Alliance projection, but it is also Waterdeep projecting into Neverember's neighborhood.
+
+## Players in Neverwinter
+
+- **Lord Protector Dagult Neverember** — sitting Alliance member; hostile to Waterdeep's executive but loyal to the Alliance form.
+- **Mintarn mercenary garrisons** (legacy) — paid Neverwinter guards for the roads under Neverember; partly displaced after Waterdeep's contract cancellations.
+- **[Lords' Alliance](../../../10-Setting/polities/lords-alliance.md)** — Neverwinter is a foundational member; Alliance fleet patrols use the harbor.
+- **Mount Hotenow's residue** — earth elementals, fire-cult survivals, and assorted post-eruption cleanup work.
+
+## Notes
+
+This stub is an anchor; Neverwinter is not the focus of the Sea-of-Swords dossier. For deeper detail consult later dossier work or the Waterdeep dossier's neighbors framing.

--- a/30-Places/sword-coast/neverwinter/character.md
+++ b/30-Places/sword-coast/neverwinter/character.md
@@ -1,0 +1,33 @@
+---
+name: neverwinter-character
+description: The rebuilt Jewel under Neverember — Alliance member, prosperous, and pointedly not Waterdeep.
+---
+
+# Character
+
+Neverwinter today is a working Sword Coast North port in the Lords' Alliance, rebuilt after the **Mount Hotenow** eruption (1451 DR) reshaped the city. Streets are wider than they were a century ago because so much of the inner city had to be re-platted from the ash; the **Neverwinter River** still runs warm year-round through the heart of the city, the ancient mage-craft that warmed it surviving the eruption.
+
+## Mood in 1502 DR
+
+Cautious confidence. Reconstruction is far enough advanced that the city behaves like itself again — guilds, markets, a working port — but not so far that the residue of the eruption and the long century of decline are forgotten. Lord Protector **Dagult Neverember** has spent a decade patronizing public works to bind the city to him; the works are real, the binding less complete than he claims.
+
+## Neverember's grievance
+
+The dossiers (Waterdeep #21, Sea of Swords #20) frame Neverember consistently: an Alliance member who runs his city well and who hates the executive of his own Alliance. The Waterdeep ouster (~1489 DR) is the wound; the **Luskan accession** debate is the live arena.
+
+Read his Neverwinter as a polity that votes Alliance and acts independent. Neverember's Mintarn contracts (now lapsed) and his road-protection budgets were funded out of Neverwinter's own purse, not Waterdeep's; he is fiscally and politically self-sufficient.
+
+## Useful to whom
+
+- **Mercenaries** north of the Sword Coast — Neverwinter is the senior Alliance recruiter once Mintarn fell off.
+- **Couriers** carrying intra-Alliance correspondence — the Open Lord and the Lord Protector communicate through formal envoys, not directly.
+- **Harpers** — Neverember's court has a Harper presence as it has had for decades; Neverember tolerates them because they are not Waterdhavian.
+
+## Avoid
+
+- Pitching anything that requires Waterdeep's blessing first. Neverember will not be a junior partner.
+- Mintarn-flagged escorts in Neverwinter's harbor at the moment. The contracts are over and the politics are sour.
+
+## Source
+
+This stub draws on `.context/converted/dossier-sea-of-swords.md` (Mintarn, Trade Routes) and `30-Places/sword-coast/waterdeep/neighbors.md`. A dedicated Neverwinter dossier is not in the campaign's current ingest queue.

--- a/30-Places/sword-coast/orlumbor/README.md
+++ b/30-Places/sword-coast/orlumbor/README.md
@@ -1,0 +1,32 @@
+---
+name: orlumbor
+description: The Forge of the Sea — Lords' Alliance shipwright island southwest of Waterdeep, defended by Alliance navy and its own discretion.
+---
+
+# Orlumbor
+
+Quiet workshop-island lying southwest of Waterdeep along the Sword Coast Run. Famous for its **shipwrights** — the cogs, caravels, and war galleys built in Orlumbor's sea-cave docks supply the Lords' Alliance navy and the wealthier merchant houses across the coast.
+
+Member of the [Lords' Alliance](../../../10-Setting/polities/lords-alliance.md). Defended by alliance and reputation rather than any large standing force.
+
+## What's here
+
+- [character.md](character.md) — the shipyard discipline, the Seaworthy Stoop, and an island that prefers to sell ships rather than fight from them.
+
+## Why it matters
+
+- **Strategic asset.** Orlumbor is the only safe friendly harbor between Waterdeep and Baldur's Gate. Any Alliance loss of Orlumbor means a much longer convoy stretch through hostile or empty water.
+- **The fleet's backbone.** Bloodwave's reavers threatened to sack Orlumbor in 1496 DR before Waterdeep's navy intercepted; the masters have since reinforced harbor defenses with catapults and a hired wizard who can raise watery walls in the bay.
+- **Alliance integration.** A small garrison of alliance marines is stationed discreetly on the island, ostensibly "training." Alliance navy vessels pay no docking fees — a quiet courtesy.
+- **The timber chain.** Orlumbor's own trees were felled long ago; constant timber shipments arrive from the **Trollbark Forest** fringes (risky to log, excellent wood). Anyone who wants to interrupt Alliance shipbuilding strikes Trollbark, not Orlumbor.
+
+## Players around Orlumbor
+
+- **Shipwright families** — effective government; led by a Harbormaster-Governor.
+- **Lords' Alliance marines** — quiet permanent garrison.
+- **Hired wizard** — currently named only as "the bay wizard"; raises watery walls when invoked.
+- **Trollbark loggers** — independent; lose people to Trollbark's resident dangers regularly.
+
+## Notes
+
+Visitors are few; the island has one tavern (the **Seaworthy Stoop**). Foreign agents trying to lure away craftsmen, if caught, are stocked and expelled on the next ship out. There is little here for idle travelers — but a working shipwright with skills will find the place welcoming and the pay honest.

--- a/30-Places/sword-coast/orlumbor/character.md
+++ b/30-Places/sword-coast/orlumbor/character.md
@@ -1,0 +1,43 @@
+---
+name: orlumbor-character
+description: Quiet, precise, discreet — the saying is "measure twice, cut once, speak never."
+---
+
+# Character
+
+Approaching Orlumbor by sea, you line up to a beacon on the dark cliffs and trust a local pilot to guide you past unmarked reefs. The harbor is cut directly into the rock: broad ramps, sea-caves where ships are built under cover, tunnels connecting workshops. The harbor floor is dredged deep enough for any galleon afloat.
+
+## Discipline
+
+Law on Orlumbor is strict and sensible:
+
+- **No brawling that could endanger a ship.**
+- **No theft of designs or tools.**
+- **No foreign agents trying to lure away craftsmen.**
+
+Those last get put in stocks and expelled on the next outbound ship. Visitors are rare; the **Seaworthy Stoop** is the island's one tavern and serves shipwrights drinking on Highsun. Foreign captains who behave well will be paid in honest coin and treated correctly. Foreign captains who behave badly will not stay foreign captains for long.
+
+## Defense
+
+Orlumbor keeps almost no standing army. Its defense is the Lords' Alliance, the discreet alliance-marine garrison, the hired wizard who raises watery walls in the bay, and the catapults installed after Bloodwave's near-sack in 1496 DR.
+
+The cultural disposition is **don't fight from the ships, sell the ships**. Orlumbor's masters prefer that wars happen elsewhere on hulls Orlumbor built.
+
+## Faith and craft
+
+The folk revere **Valkur** and **Gond** along with a healthy respect for **Talos**. Superstition and craft mix: shipwrights here often carve tiny runes of protection into keels — half engineering, half prayer. The local saying — "Our walls are wooden and they float" — captures the strategic doctrine and the religious stance at once.
+
+## Useful to whom
+
+- **Captains needing a hull repaired** — best work on the coast.
+- **Buyers in the market for a fast cog or a war galley** — order takes a season; the wait is worth it.
+- **Alliance officers** carrying letters between Waterdeep and Baldur's Gate — Orlumbor is a polite, fast turnaround for couriers who do not want to be seen.
+
+## Avoid
+
+- Mentioning Amnian interest. The 1490s attempt by Amnian creditors to leverage debt into ownership of the shipyards is a sore memory.
+- Recruiting craftsmen for any other yard. You will be stocked, expelled, and remembered.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Orlumbor section.

--- a/30-Places/sword-coast/purple-rocks.md
+++ b/30-Places/sword-coast/purple-rocks.md
@@ -1,0 +1,31 @@
+---
+name: purple-rocks
+description: Small Northlander archipelago northwest of Ruathym; surface settlement, unsettling worship, drowned Ascarle below.
+---
+
+# The Purple Rocks
+
+Small island cluster northwest of **Ruathym**. Insular Northlander locals live above water; below water the drowned elven city of **Ascarle** has for centuries been the lair of **Slarkrethel** and the **Kraken Society**.
+
+For the cabal and the kraken see [10-Setting/regions/sea-of-swords.md](../../10-Setting/regions/sea-of-swords.md) and [10-Setting/polities/luskan-and-the-pirates.md](../../10-Setting/polities/luskan-and-the-pirates.md).
+
+## Above water
+
+- **The Watcher in the Waves** — the locals' deity, almost certainly Slarkrethel under another name. Worship is collective: at dusk the islanders gather on the shore and chant at the sea.
+- **Hospitality.** Polite, distant. Travelers describe an eerie courtesy. More than one visitor has vanished overnight.
+- **What is sold here.** Replenishment of fresh water, occasional whale meat. Almost nothing else.
+
+## Below water
+
+- **Ascarle** — half-ruined elven city, now drowned and repurposed as the Kraken's lair. Crystal spires and air-filled domes; merrow, scrags, an illithid vizier or two attend. Sea elves whisper of plots against the surface.
+- **1501 DR Harper missive** — unusual tides around the Rocks; something large shifted on the ocean floor. Whether Ascarle is rising or a new portal opened from the depths, no one knows.
+
+## Rules for visitors
+
+- **Do your business and depart by nightfall.**
+- **Do not follow strange singing on the wind.**
+- **Do not wander far inland.** Those who pry too much are reported to end as sacrifices in underwater grottoes.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Kraken Society & Shadow in the Deep chapter.

--- a/30-Places/sword-coast/ruathym/README.md
+++ b/30-Places/sword-coast/ruathym/README.md
@@ -1,0 +1,34 @@
+---
+name: ruathym
+description: Axehome of the Northlanders — far-northwest Northlander island closed to outsiders since 1498 DR by the First Axe Vok Dorrg.
+---
+
+# Ruathym
+
+Northlander island far to the northwest, beyond the Moonshaes and the Trackless Sea storms. Jagged south coast of high cliffs; pebble beaches on the north. The single major harbor is at the town of **Ruathym** itself (often called **Gundarlun's Gate** locally), facing the neighboring Northlander kingdom across the water.
+
+Ancestral homeland of the Northlanders — proud, suspicious, hard. Closed to outsiders since 1498 DR by decree of the **First Axe**.
+
+## What's here
+
+- [character.md](character.md) — the longhouses with dragon-head gables, the moot, the First Axe's grudges.
+
+## Why it matters
+
+- **The closed door.** **Vok Dorrg** — blind aging warrior-priest of Valkur — closed Ruathym's ports in 1498 DR after watching mainland fleets in northern waters: *"Let the south bleed; we guard our own fjords."* Luskanite diplomats, Alliance traders, even Northlander cousins from other isles have been turned away ever since.
+- **The Luskan grudge.** A century of bad blood with Luskan persists. Most Ruathym folk spit at the city's name. The recent secret meeting between **Captain Kurth of Luskan** and an envoy of Ruathym was therefore astonishing — and may presage a revival of the old **Captains' Alliance** between Luskan and Northlander isles against the bigger mainland nations.
+- **The Harper exception.** Harpers move freely on Ruathym, the only outsider faction that does. A famous Harper bard once saved the First Axe's son from assassination years ago; the door has been open to known Harpers since.
+- **The Kraken Society probe.** The Society tried to seed a cult here in 1496 DR, luring disaffected youths with promises of power; the cultists were found drowned. The Society has not stopped trying.
+
+## Players around Ruathym
+
+- **First Axe Vok Dorrg** — ruler; aging; iron-willed.
+- **Clan chiefs** — meet in the great hall in **moot**; resolve disputes by argument or fist.
+- **Priests of Tempus and Valkur** — the dominant faiths; Umberlee receives only grudging tribute.
+- **Rhaumon Bloodaxe's ghost** (rumored) — a past First Axe haunting the shoreline, calling for vengeance on Luskan.
+- **The Kraken Society** — kept out so far. Drowned cultists 1496 DR.
+- **Harpers** — quiet welcome; no formal cell.
+
+## Notes
+
+A non-Northlander arriving in Ruathym is suspect; a non-human arriving may be attacked outright. **Tie weapons to the belt** in town — old custom. Bring a cask of good ale as dock-gift if you come in peace; bring nothing of Luskan if you value your skull as anything but a drinking-bowl.

--- a/30-Places/sword-coast/ruathym/character.md
+++ b/30-Places/sword-coast/ruathym/character.md
@@ -1,0 +1,41 @@
+---
+name: ruathym-character
+description: Hard, proud, and remembering — Ruathym lives by oar, axe, and feud, and remembers every old wrong.
+---
+
+# Character
+
+Coming into Ruathym's bay, you see longhouses with dragon-head gables and a stockade wall. There is no formal harbormaster; weapons must be tied to the belt in town (an old custom to prevent sudden draws). If you have come in peace, present a cask of good ale to the dock sentry as a "dock gift." If you have come to raid, you will find out soon enough that Ruathym gives as good as it gets.
+
+## Lifestyle
+
+Hard. Every child can row and gut a fish by ten. The people survive by fishing, whale hunting, and the occasional raid — usually aimed at hated Luskan or rival islands now, less often at the mainland. **Moot**, when clan chiefs meet in the great hall to hash out disputes or plan voyages, is the central political event. It often ends in as many broken noses as agreements.
+
+## Faith
+
+**Tempus** and **Valkur** are the dominant gods. Umberlee receives sacrifice only grudgingly and with curses. **Rhaumon Bloodaxe** — a past First Axe — is rumored to haunt the shoreline, calling for vengeance on Luskan; the priests neither confirm nor deny.
+
+## The First Axe's politics
+
+**Vok Dorrg** plays on the island's wounded pride to keep his people united. Old grievances — Luskan's century-ago war, Kraken Society plots, mainland fleets in northern waters — are kept alive deliberately. Closing the ports in 1498 DR was the consummation of a long policy, not a sudden pivot.
+
+But isolation has costs. **Trade is cut.** Food can run short in bad winters; the island nearly starved in 1501 until a bumper catch of whales saved the day. The youth grow restless with no battles to fight and old enemies still living. How long Vok Dorrg can keep Ruathym out of a fight — perhaps the Captains' Alliance revival, perhaps a Kraken Society retaliation — the waves cannot say.
+
+## Ships
+
+Northlanders are fine shipbuilders. Ruathym docks turn out **longships and knarrs**: light, fast, function-over-form. Less adornment than Norland raiders prefer, just as seaworthy.
+
+## Useful to whom
+
+- **Harpers** carrying messages north — Ruathym is the only safe northern node outside the closed Northlander isles.
+- **Captains running whale oil south** — the price for an outsider buyer is steep, the volume real.
+- **Rangers chasing Kraken cultists** — Ruathym's priests will tell you what they know.
+
+## Avoid
+
+- Bringing **Luskan wine** as a gift. The jarl's thane will use your skull as the drinking bowl.
+- Open inquiries about the Captains' Alliance. The First Axe denies it; some clans want it; talking about it openly puts you between them.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Ruathym section; Luskan section (Captains' Alliance revival).

--- a/30-Places/sword-coast/skaug/README.md
+++ b/30-Places/sword-coast/skaug/README.md
@@ -1,0 +1,31 @@
+---
+name: skaug
+description: Neutral pirate haven of the Nelanther Isles — fence-port, recruiting ground, and the last truly neutral water on the Sword Coast.
+---
+
+# Skaug
+
+Pirate haven hidden behind spiny reefs in the Nelanther Isles. Approached at high tide following three rock spires locals call the **Widow's Teeth**. The anchorage is crowded and shallow; moorings are first-come, rafted three deep at need.
+
+## What's here
+
+- [character.md](character.md) — the dock-boss racket, Truce Tide, and a town where every alehouse has a knife under the table.
+
+## Why it matters
+
+- **The Sword Coast's biggest fence.** Anything stolen finds a buyer here — slaves (mostly southbound to Calimshan), spices, weapons, opium, counterfeit coin. **Fresh water and salted fish** are ironically among the priciest goods because pirates value them most.
+- **Truce Tide.** Skaug observes a working truce — any crew is safe so long as they do not draw steel or steal local booty. Disputes settle outside the harbor at dawn or in the **Broken Oar tavern's fighting pit** by an agreed referee.
+- **Recruiting and parley.** Pirate recruiters always seek hands for the next raid on Amnian galleons. Less risky jobs include guiding smugglers through reef channels or salvaging wrecks (often under the eye of who caused the wreck).
+- **Blackmane's tax.** **Admiral Austarl Blackmane** permits Skaug to remain free so pirates spend their plunder here, then "gift" him a cut. The fence-port and the Sea King are symbiotic.
+
+## Players around Skaug
+
+- **Dock-boss Kalzhak** — one-eyed orc; 2 gp gets a week's dock space, double if your hold looks full. No formal harbor authority above him.
+- **Mother Yola** — head priestess at the **shrine of the Fanged Lady** (Umberlee). Trades blessings for gold; supposedly calms storms or calls sharks with a word.
+- **Sea Tower wardens** — old wizards in black who guard certain isles with spells; rare in town, never to be crossed.
+- **Free Captains** — dozens; orcish reaver-bands, human privateers with thin claims of legitimacy. Toast no king since Bloodwave; alliances by the moon.
+- **Mainland meddlers** — Lords' Alliance patrols (rare and in force only), Amnian privateer-handlers, [Zhentarim](../../../20-Factions/zhentarim/summary.md) quartermasters. Few Nelanther pirates trust them; gold is gold.
+
+## Notes
+
+The town has no formal law. The **Black Gull** tavern is the dossier author's local; the **Broken Oar** is for pit fights and dispute-resolution. Never cheat the **Umbers** of their tribute; cocky freebooters have been found drowned in barrels for skimping.

--- a/30-Places/sword-coast/skaug/character.md
+++ b/30-Places/sword-coast/skaug/character.md
@@ -1,0 +1,46 @@
+---
+name: skaug-character
+description: Truce Tide and the Black Gull — a fence-port that runs on bribery, prudence, and Umberlee's tribute.
+---
+
+# Character
+
+Skaug smells of pitch, salt, fish, and the sour ferment of cheap rum. Dockside is loud at all hours; warehouses behind the quay have no signage and no questions. Every alehouse has a knife under the table.
+
+## How the day works
+
+- **Dock fee** — 2 gp to Kalzhak's hand, doubled if your hold looks full.
+- **Tribute** — toss a coin or a kill to Umberlee on arrival. Skipping it is a recognized offense; survivors who refused this and lived to tell are scarce enough that the story is rarely repeated.
+- **Disputes** — outside the harbor at dawn, or pit-fight in the Broken Oar.
+- **Loading** — slaves and stolen luxury go out by night; bulk grain comes in by day. Information moves at all hours.
+
+## Atmosphere
+
+The dossier captures it: a Skaug grog-house argument about whether Bloodwave still lives can nearly turn into a knife-fight before the barkeep cocks a crossbow. The price of being there is keeping your head down. Truth and lies drink from the same cup.
+
+## What you can sell here
+
+- Slaves (going to Calimshan).
+- Spices and silks (cheap; dangerous to fence on the mainland).
+- Captives held for ransom (bring proof of identity).
+- Charts of new patrol routes, captain's secret signal codes, names of bribed dockhands. **Information is coin** in Skaug — sometimes outpriced a chest of gold.
+
+## What you cannot sell here
+
+- Plague medicine without paying the Umbers their cut.
+- Anything Mother Yola has put a sea-curse on. Word travels.
+
+## Useful to whom
+
+- **Privateers and pirates** — recruiting and fencing.
+- **Spies** — neutral ground for parleys nobody wants official.
+- **Investigators chasing missing cargo** — most of it ends up here within a tenday of the theft.
+
+## Avoid
+
+- The **shrine of the Fanged Lady** uninvited. Mother Yola sets the price of disrespect.
+- Any meeting in the **Ruins** north of the cove. The Sea Tower wardens watch.
+
+## Source
+
+`.context/converted/dossier-sea-of-swords.md` — Nelanther chapter; Skaug subsection.

--- a/40-Timeline/history.md
+++ b/40-Timeline/history.md
@@ -31,6 +31,20 @@ Titania convened the [Court of Stars](../10-Setting/cosmology/fey-courts/court-o
 
 The bards have begun calling this conclave the **"Conclave of Mirrors,"** for the moment when each court came face-to-face with its rival and saw equally terrified eyes staring back.
 
+## 1492–1502 DR — The Sea of Swords, decade of churn
+
+Western-water events recorded by Greywake's dossier. World-visible only; deep-water horrors are rumor unless otherwise noted.
+
+- **1492 DR — Year of Three Ships Sailing.** Half-orc corsair **Ghorin Bloodwave** forges the **Black Flag Fleet** in the Nelanther; the Storm Maiden tightens her grip on Norland and Oman; Amnian soldiery entrenches on **Snowdown**.
+- **1494 DR — Battle of Gull Rock.** Bloodwave's fleet smashes an Amnian convoy off the Nelanther, seizing enough coin to buy a hundred new ships. The Northlanders raid Callidyrr's coasts under the Storm Maiden; High King Derid's dragoons cannot hold the shore.
+- **1495 DR — Waterdeep cancels its Mintarn contract.** Laeral Silverhand ends Dagult Neverember–era leases of Mintarn's mercenary navy. Mintarn's coffers thin just as Hoondarrh demands greater tribute; the Tyrant's bind begins.
+- **1496 DR — Lords' Alliance push into the Nelanther.** Waterdeep and Baldur's Gate force the Alliance fleet into the pirate isles. **Kraken Society** glyphs surface in Luskan, Gundbarg, and Baldur's Gate's docks. The Society tries to seed a cult on Ruathym; cultists found drowned. Bloodwave's reavers threaten **Orlumbor** before Waterdeep's navy intercepts.
+- **1498 DR — Battle of Asavir's Channel.** Combined Lords' Alliance fleets crush Bloodwave's Black Flag Fleet at the Nelanther bottleneck. Many pirate lords die; Bloodwave's body never found. **Ruathym closes its ports** by decree of the First Axe **Vok Dorrg**: *"Let the south bleed; we will guard our own fjords."* **Hoondarrh attacks Castle Mintarn**, toppling two towers to demand more tribute.
+- **1499 DR — Green-comet impact.** A green comet plunges into the ocean west of Evermeet (summer). Captains afterward report unnatural lights beneath the water and dreamings; sages whisper of **starspawn**.
+- **1500 DR — Trade boom.** Baldur's Gate's reconstruction drives caravan and galleon traffic to a peak. Zhentarim fattens on smokepowder and spices across the Chionthar and Sea of Swords. The Storm Maiden vanishes for a season, returning with eyes like lightning. A night of three moons over Gwynneth seen by twenty crews.
+- **1501 DR — Year of the Awakened Kraken.** Whole caravels vanish in the Trackless Sea. A Harper missive reports unusual tides around the **Purple Rocks**; **Ascarle** may be stirring. **Admiral Austarl Blackmane** consolidates the Nelanther under the *Brine Hydra*. Ruathym nearly starves; saved by a bumper whale catch.
+- **1502 DR (present) — Year of the Pox Plague.** Pestilence creeps through southern ports. Blackmane sinks two Amnian frigates in open battle, announcing his reign of fear. The Tyrant of Mintarn quietly petitions the Lords' Alliance for loans and a dragonslayer. The Alliance proclaims sea lanes secure; sailors laugh in every tavern.
+
 ## 1492–1497 DR — The Crisis and the Decade of Reconstruction in Baldur's Gate
 
 - **1492 DR — Absolute Crisis (BG3).** The Cult of the Absolute, run by Chosen of the Dead Three and a Netherbrain, nearly conquers Baldur's Gate. Heroes destroy the Brain. See [absolute-crisis](../10-Setting/history/absolute-crisis.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,16 @@ Conventions for adding to this knowledge store.
 - Each markdown file should be under 500 words.
 - Consider ways to break larger files apart as you write into them, preserving connections through hyperlinks.
 
+### When a file bloats, promote it to a subfolder
+
+If a topic page or `README.md` index grows past ~500 words because the topic itself is growing, **promote it to a subfolder** rather than letting the file bloat:
+
+- A topic file `foo.md` becomes `foo/README.md` plus child files (`foo/<aspect>.md`) split along the topic's natural seams.
+- An index `README.md` whose entry list is the source of bloat is a signal to **group entries**: introduce a child subfolder for the most numerous category and move those entries into its own `README.md` index.
+- Keep cross-references working: every link in the old file should resolve to the new path after the split.
+
+Index files (`README.md`) may run a little over 500 words when the index itself is the content (one-line entries per item). Topic prose files should not.
+
 ## Places
 
 - Higher-level geographic concepts are first-class subjects, not just container folders. Regions, cities, districts, and individual sites can each have their own markdown files alongside nested subfolders.


### PR DESCRIPTION
## Summary

Distills Greywake's _Sails & Secrets on the Sword Coast_ dossier across the knowledge base per issue #20. Closes #20.

- **00-Campaign-Frame** — two new inferred principles: `sea-as-frontier.md` (the sea is unowned working infrastructure; tribute is structural) and `multipolar-coast.md` (six blocs, no hegemon).
- **10-Setting/polities** — `lords-alliance.md`, `luskan-and-the-pirates.md`, `calimshan-amn.md`. Polity-level prose; cities and dossier-color characters live elsewhere.
- **10-Setting/regions/** — new subfolder. `sea-of-swords.md` catalogs the body of water (sea-lanes, currents, named features, what lives in the deep).
- **30-Places/sword-coast/** — adds the missing regional files `character.md` and `neighbors.md`; rewires `README.md` to index everything new.
- **30-Places stubs** — full city folders for `luskan`, `neverwinter`, `mintarn`, `orlumbor`, `ruathym`, `daggerford`, `athkatla`, `calimport`, `skaug`. Macro-region single-files for `moonshae-isles.md`, `nelanther-isles.md`, `purple-rocks.md`.
- **20-Factions cross-links** — `amnian-kontor`, `waterdhavian-kontor`, `harpers`, and `zhentarim` summaries each get a "At Sword Coast scale" section linking back to the new polity/place files.
- **40-Timeline/history.md** — appends a 1492–1502 DR Sword-Coast decade (Battle of Gull Rock, Asavir's Channel, Hoondarrh's attack on Castle Mintarn, Ruathym closing its ports, the green-comet fall, the Pox Plague, etc.).

No new factions promoted to first-class status — Bloodwave, Blackmane, the Storm Maiden, the Kraken Society, Hoondarrh have no agency in `faction-quests.xlsx` and per the issue are kept as polity-level dossier color in `10-Setting/polities/luskan-and-the-pirates.md`.

## Test plan

- [ ] Spot-check 2-3 city stubs (e.g. `luskan/`, `mintarn/`) for tone consistency with existing stubs (`beregost/`, `nashkel/`).
- [ ] Confirm cross-references resolve in your editor (zero broken links checked locally).
- [ ] Confirm the `10-Setting/regions/` subfolder convention reads cleanly alongside `polities/` and `history/`.
- [ ] Verify the timeline insertion order in `40-Timeline/history.md` reads naturally before the BG reconstruction block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)