### PR TITLE
Stand up 60-Threads/ as an active-threads roll-up

### DIFF
--- a/.claude/skills/dm-scene/SKILL.md
+++ b/.claude/skills/dm-scene/SKILL.md
@@ -18,6 +18,7 @@ The repo is large. Do not walk faction or place trees blindly. For a scene-openi
 3. **`50-Sessions/session_<N>/gm_summary.md`** — private intent / behind-the-scenes for that session (may be a stub pointing back to the player summary; that's fine).
 4. **`40-Timeline/week_<W>/events.md`** — the world's parallel motion that week.
 5. **`20-Factions/party/summary.md`** — current party leverage, debts, open threads.
+6. **`60-Threads/README.md`** — the active-threads roll-up. One table; tells you what's owed by whom and when it comes due. Cheaper than mining `summary.md` prose.
 
 Once you can name the district the scene lands in (the last session's summaries usually make it obvious), add **one** Stage-1.5 read: the matching district roll-up at `30-Places/sword-coast/baldurs-gate/<district>/events.md`. The candidates are:
 

--- a/60-Threads/CONTRIBUTING.md
+++ b/60-Threads/CONTRIBUTING.md
@@ -1,17 +1,38 @@
 # Contributing — Threads
 
+A thread is one dangling arc. One file per thread, one row per thread in [README.md](README.md). Files are flat under `60-Threads/` — no subfolders.
+
 ## File shape
 
 ```
-<thread-slug>.md
+---
+name: <thread-slug>
+description: <one-line summary — who owes what to whom, or what's unanswered>
+status: open | dormant | resolved
+introduced: session_<N> / week_<W>
+owed_by: <faction or NPC slug>
+owed_to: <faction or NPC slug>
+due: <when it likely matures — week, condition, or "open">
+---
+
+# <Thread title>
+
+<2-4 sentences of context. Link to the canonical pages where the thread originated and any subsequent appearances. Do not restate detail that already lives on those pages — link out.>
+
+## See also
+- <links to the canonical session, faction `activity/`, or place `events.md` files>
 ```
 
-Each file should record:
-- What is known.
-- Who told us / where it came from (source link).
-- Who/what it might involve.
-- Open questions.
+Slugs use kebab-case and should make the thread identifiable from the index alone (`fey-bargains-elia-bror`, not `bargains`).
+
+## Index
+
+[README.md](README.md) is a single table — one row per thread. Add or remove rows as threads open or resolve. Keep `Owed by` / `Owed to` / `Status` / `Due` aligned with the file's frontmatter.
+
+## When to open a thread
+
+When something concrete is left unresolved that a future scene might pick up: a debt owed, a question the party asked that has no answer yet, an NPC's hidden knowledge of the party, a piece of intel the party holds that hasn't been spent. Threads are not for prose flavor or generic future possibilities — only for items the party (or an NPC against the party) could plausibly cash in.
 
 ## Graduation
 
-A thread graduates out of this folder when it resolves: the resolution lands in `40-Timeline/`, `20-Factions/<faction>/activity/`, or `30-Places/<location>/events.md` as appropriate, and the thread file is deleted (or kept with a "resolved" note linking to the resolution).
+A thread graduates when it resolves: the resolution lands in `40-Timeline/`, `20-Factions/<faction>/activity/`, or `30-Places/<location>/events.md` as appropriate. Mark the thread `status: resolved` and link the resolution from `## See also`, or delete the file and remove its row from the index. Either is fine; prefer deletion for routine resolutions, prefer the resolved-with-link form when the thread shaped multiple weeks.

--- a/60-Threads/README.md
+++ b/60-Threads/README.md
@@ -1,9 +1,19 @@
 # Threads
 
-Rumors, leads, and unresolved arcs. Anything dangling — a name dropped without context, a question the party asked that hasn't been answered, a hook waiting for someone to bite.
+Rumors, leads, and unresolved arcs. Anything dangling — a name dropped without context, a question the party asked that hasn't been answered, a hook waiting for someone to bite. One row per active thread; the file behind each row holds the context and links back to its canonical origin.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for file shape and graduation rules.
 
 ## Index
 
-_(empty — populate as threads emerge)_
+| Thread | Owed by | Owed to | Status | Due |
+|--------|---------|---------|--------|-----|
+| [Two unpaid fey bargains to the mirror-tent proprietor](fey-bargains-elia-bror.md) | party | mirror-tent-proprietor | open | proprietor will collect |
+| [Nine-Fingers Keene's pending verdict on the Vex killing](nine-fingers-vex-verdict.md) | astele-keene | party | open | verdict pending |
+| [The Whispering Stone's passive listening through Bror](whispering-stone-needle-network.md) | ettvard-needle | party | open | open |
+| [The Karak-Dur cipher](karak-dur-cipher.md) | clan-iron-eye (lore) | party | open | solstice |
+| [The Underdark psionic star-chart (un-decoded)](underdark-psionic-star-chart.md) | unknown | party | open | requires the missing key |
+| [The Credential of Balduran's "old company tradition"](credential-old-company.md) | ettvard-needle | party | open | open |
+| [The propaganda cart the Consortium does not know it lost](consortium-propaganda-cart.md) | party | chionthar-consortium | open | when Consortium notices, or party publishes |
+| [Errinthal's secret funding of Mad Meggan](errinthal-funds-meggan.md) | party | mad-meggan | open | when party shows the receipts |
+| [The Symbian intellect-devourer offer Bror heard](symbian-intellect-devourer-offer.md) | bror | the-skittering-beetle | open | terms uncertain |

--- a/60-Threads/consortium-propaganda-cart.md
+++ b/60-Threads/consortium-propaganda-cart.md
@@ -1,0 +1,20 @@
+---
+name: consortium-propaganda-cart
+description: The party holds the Chionthar Consortium's anti-Amnian propaganda cart; the Consortium does not yet know it was lost.
+status: open
+introduced: session_1 / week_1
+owed_by: party
+owed_to: chionthar-consortium
+due: open — fires when the Consortium notices, or when the party publishes
+---
+
+# The propaganda cart the Consortium does not know it lost
+
+In [week 1](../20-Factions/party/activity/week_1/heist-the-rivington-medicine-cart.md), Elia took a second cart on impulse from a [Chionthar Consortium](../20-Factions/chionthar-consortium/summary.md) warehouse during the Open Hand medicine heist — later identified as carrying anti-Amnian propaganda the Consortium had been about to deploy publicly. The medicine reached the Open Hand; the second cart became leverage banked against the Consortium. Vex's locked-desk intel in week 5 confirmed [Factor Errinthal's](../20-Factions/chionthar-consortium/people/factor-errinthal.md) anti-refugee print campaign needs only the print blocks the party has been holding to publish — which makes those blocks the loudest unfired weapon the party owns.
+
+## See also
+
+- [Party — Heist the Rivington Medicine Cart](../20-Factions/party/activity/week_1/heist-the-rivington-medicine-cart.md)
+- [Party — Kill Vex and Loot Her Office](../20-Factions/party/activity/week_5/kill-vex-and-loot-her-office.md)
+- [Chionthar Consortium](../20-Factions/chionthar-consortium/summary.md)
+- [Factor Errinthal](../20-Factions/chionthar-consortium/people/factor-errinthal.md)

--- a/60-Threads/credential-old-company.md
+++ b/60-Threads/credential-old-company.md
@@ -1,0 +1,20 @@
+---
+name: credential-old-company
+description: Ettvard Needle called the Credential of Balduran "an old company tradition" without naming the company; the identity of that company is unanswered.
+status: open
+introduced: session_21 / week_5
+owed_by: ettvard-needle
+owed_to: party
+due: open — answer would explain who else in the city carries one
+---
+
+# The Credential of Balduran's "old company tradition"
+
+When [Ettvard Needle](../20-Factions/baldurs-mouth/people/ettvard-needle.md) handed Kaelan [the Credential of Balduran](../20-Factions/baldurs-mouth/associations/credential-of-balduran.md) in [session 21](../50-Sessions/session_21/player_summary.md), he called it *"an old company tradition"* — without naming the company. The dossier does not enumerate other living holders by name, but assumes one or two are out there from the pre-week-7 era. Whose tradition the Credential actually descends from, and which surviving members of that company still expect to be honored by it, are unanswered.
+
+## See also
+
+- [Session 21](../50-Sessions/session_21/player_summary.md)
+- [The Credential of Balduran](../20-Factions/baldurs-mouth/associations/credential-of-balduran.md)
+- [Ettvard Needle](../20-Factions/baldurs-mouth/people/ettvard-needle.md)
+- [Party — Install Finneas as Guild Boss of Rivington](../20-Factions/party/activity/week_5/install-finneas-as-guild-boss-of-rivington.md)

--- a/60-Threads/errinthal-funds-meggan.md
+++ b/60-Threads/errinthal-funds-meggan.md
@@ -1,0 +1,19 @@
+---
+name: errinthal-funds-meggan
+description: Factor Errinthal is secretly funding 'Mad' Meggan to keep the blockade alive; party knows, Meggan does not yet know they know.
+status: open
+introduced: session_20 / week_5
+owed_by: party
+owed_to: mad-meggan
+due: open — fires whenever the party shows Meggan the receipts
+---
+
+# Errinthal's secret funding of Mad Meggan
+
+In [session 20](../50-Sessions/session_20/player_summary.md) the party's intelligence shake-out confirmed [Factor Errinthal](../20-Factions/chionthar-consortium/people/factor-errinthal.md) has been quietly funding ['Mad' Meggan](../20-Factions/free-traders-of-the-outskirts/people/mad-meggan.md) — not to help her win, but to keep the Basilisk Gate blockade alive indefinitely so the Consortium's river monopoly compounds. Meggan does not yet know she is being played, and does not yet know the party knows. The party has the receipts, and a choice about when to spend them.
+
+## See also
+
+- [Session 20](../50-Sessions/session_20/player_summary.md)
+- [Factor Errinthal](../20-Factions/chionthar-consortium/people/factor-errinthal.md)
+- ['Mad' Meggan](../20-Factions/free-traders-of-the-outskirts/people/mad-meggan.md)

--- a/60-Threads/fey-bargains-elia-bror.md
+++ b/60-Threads/fey-bargains-elia-bror.md
@@ -1,0 +1,19 @@
+---
+name: fey-bargains-elia-bror
+description: Elia and Bror each owe the mirror-tent proprietor one true secret, payable on her terms.
+status: open
+introduced: session_10 / week_3
+owed_by: party
+owed_to: mirror-tent-proprietor
+due: open — proprietor will surface to collect
+---
+
+# Two unpaid fey bargains to the mirror-tent proprietor
+
+At the [Circus of the Last Days](../20-Factions/carnival-of-whispers/summary.md) in week 3, Elia and Bror each accepted a fey bargain from [the mirror-tent proprietor](../20-Factions/carnival-of-whispers/people/mirror-tent-proprietor.md): one true secret each, never told another soul, owed at a later date in exchange for a vision of a perfected future. Bror's secret is "about the oath he swore in the dark." Both bargains remain unpaid. The proprietor's pattern is to collect by appearing in dreams, ambushing in alleys, or sending a Memory Mite.
+
+## See also
+
+- [Party — Infiltrate the Circus of the Last Days](../20-Factions/party/activity/week_3/infiltrate-the-circus-of-the-last-days.md)
+- [The mirror-tent proprietor](../20-Factions/carnival-of-whispers/people/mirror-tent-proprietor.md)
+- [Session 10](../50-Sessions/session_10/player_summary.md)

--- a/60-Threads/karak-dur-cipher.md
+++ b/60-Threads/karak-dur-cipher.md
@@ -1,0 +1,18 @@
+---
+name: karak-dur-cipher
+description: Decoded ciphers from *The Stonemason's Secret* point to a lost dwarven forge — *THE FORGE THINKS STILL* / *FOLLOW SOLSTICE SUN FROM KARAK-DUR*.
+status: open
+introduced: session_12 / week_5
+owed_by: clan-iron-eye (lore)
+owed_to: party
+due: solstice — direction-finding requires solstice sun from Karak-Dur
+---
+
+# The Karak-Dur cipher
+
+Bror picked up *The Stonemason's Secret* at [The Pilgrim's Parchment](../20-Factions/party/activity/week_5/the-pilgrims-parchment-buy.md) in week 5; the party decoded two ciphers from it — a letter-to-number message *"THE FORGE THINKS STILL"* and a chapter-title acrostic *"FOLLOW SOLSTICE SUN FROM KARAK-DUR"*. The text is a relic of the lost dwarven Clan Iron Eye and points to a forge that tempers will and forges sentient constructs. The party has the cipher but no Karak-Dur location and no surveyed solstice line.
+
+## See also
+
+- [Party — The Pilgrim's Parchment Buy](../20-Factions/party/activity/week_5/the-pilgrims-parchment-buy.md)
+- [Session 12](../50-Sessions/session_12/player_summary.md)

--- a/60-Threads/nine-fingers-vex-verdict.md
+++ b/60-Threads/nine-fingers-vex-verdict.md
@@ -1,0 +1,20 @@
+---
+name: nine-fingers-vex-verdict
+description: Guildmaster Astele "Nine-Fingers" Keene has not yet ruled on the party's killing of her Rivington Lieutenant Vex.
+status: open
+introduced: session_15 / week_5
+owed_by: astele-keene
+owed_to: party
+due: open — verdict pending; Rivington Gambit is a race to reach Keene before the truth does
+---
+
+# Nine-Fingers Keene's pending verdict on the Vex killing
+
+In session 15 the party killed [Vex](../20-Factions/guild/people/vex.md) in a [Gray Harbour warehouse ambush she initiated](../20-Factions/party/activity/week_5/kill-vex-and-loot-her-office.md) to seize the Whispering Stone, and walked out with her appointment book, her ciphered Velvet Hand confession, and her unsent betrayal note to Keene. [Nine-Fingers](../20-Factions/guild/people/astele-keene.md) does not yet know which version of events to believe; the [Rivington Gambit](../20-Factions/party/activity/week_5/install-finneas-as-guild-boss-of-rivington.md) is structured to reach her with a public-service-franchise pitch before the truth does. Session 21 closes the week with no verdict yet sent.
+
+## See also
+
+- [Party — Kill Vex and Loot Her Office](../20-Factions/party/activity/week_5/kill-vex-and-loot-her-office.md)
+- [Astele "Nine-Fingers" Keene](../20-Factions/guild/people/astele-keene.md)
+- [Party — Install Finneas as Guild Boss of Rivington](../20-Factions/party/activity/week_5/install-finneas-as-guild-boss-of-rivington.md)
+- [Session 15](../50-Sessions/session_15/player_summary.md), [Session 21](../50-Sessions/session_21/player_summary.md)

--- a/60-Threads/symbian-intellect-devourer-offer.md
+++ b/60-Threads/symbian-intellect-devourer-offer.md
@@ -1,0 +1,19 @@
+---
+name: symbian-intellect-devourer-offer
+description: A skittering beetle-shaped presence whispered offers to Bror and Elia at the Plowman during a Symbian mercenary shakedown; Bror's deal terms remain uncertain.
+status: open
+introduced: session_12 / week_5
+owed_by: bror
+owed_to: the-skittering-beetle
+due: open — a deal was struck; terms and consequences are uncertain
+---
+
+# The Symbian intellect-devourer offer Bror heard
+
+In [session 12](../50-Sessions/session_12/player_summary.md) at the [Weary Plowman](../30-Places/sword-coast/baldurs-gate/outer-city/rivington.md), three Symbian mercenaries shoulder in to extort a refugee family under the Archduke's "Emergency Commerce Protection Act." A skittering, beetle-shaped *presence* speaks into Bror's deaf mind and into Elia's, offering each a different transactional favor — to "create a shadow in the soul" of the sergeant, or to pry open his "lock box of useful secrets." Bror accepted a deal from this Beetle Soul Broker; per [his page](../20-Factions/party/people/bror.md), terms and consequences remain uncertain. The Beetle resurfaces in week 6 as [the Skittering Beetle](../20-Factions/takers-of-the-tithe/people/the-skittering-beetle.md).
+
+## See also
+
+- [Session 12](../50-Sessions/session_12/player_summary.md)
+- [Bror "The Shadow Stone"](../20-Factions/party/people/bror.md)
+- [The Skittering Beetle](../20-Factions/takers-of-the-tithe/people/the-skittering-beetle.md)

--- a/60-Threads/underdark-psionic-star-chart.md
+++ b/60-Threads/underdark-psionic-star-chart.md
@@ -1,0 +1,18 @@
+---
+name: underdark-psionic-star-chart
+description: Elia holds an untitled scaly-leather book linking illithid psionics to star charts not visible from Faerûn — missing a foundational key to read.
+status: open
+introduced: session_12 / week_5
+owed_by: unknown
+owed_to: party
+due: open — requires the missing key
+---
+
+# The Underdark psionic star-chart (un-decoded)
+
+Elia took the **untitled scaly-leather book** from [The Pilgrim's Parchment](../20-Factions/party/activity/week_5/the-pilgrims-parchment-buy.md) — a dense Underdark scientific text linking illithid psionics to unknown star charts not visible from Faerûn. The text is clearly missing a foundational "key" the party does not yet hold, and it remains undecoded. Whoever holds the key likely has cause to want this book back.
+
+## See also
+
+- [Party — The Pilgrim's Parchment Buy](../20-Factions/party/activity/week_5/the-pilgrims-parchment-buy.md)
+- [Session 12](../50-Sessions/session_12/player_summary.md)

--- a/60-Threads/whispering-stone-needle-network.md
+++ b/60-Threads/whispering-stone-needle-network.md
@@ -1,0 +1,20 @@
+---
+name: whispering-stone-needle-network
+description: Bror's Whispering Stone is passively listening to Ettvard Needle's eavesdropping network; Needle does not know.
+status: open
+introduced: session_8 / week_2 (attunement); session_20 / week_5 (network routing)
+owed_by: ettvard-needle
+owed_to: party
+due: open — bears fruit whenever the Mouth runs a "scoop"
+---
+
+# The Whispering Stone's passive listening through Bror
+
+Bror [attuned the Whispering Stone in week 2](../20-Factions/party/activity/week_2/attune-to-the-whispering-stone.md) at the Penumbra Playhouse with [Mother Nocturne's](../20-Factions/silent-shroud/people/mother-nocturne.md) ritual guidance, embedding the [Silent Shroud](../20-Factions/silent-shroud/summary.md) in the party's intelligence stream. In [session 20](../50-Sessions/session_20/player_summary.md) the stone began picking up alien-language fragments Bror recognized as the same "scoops" the *Baldur's Mouth* has been printing — meaning [Ettvard Needle's](../20-Factions/baldurs-mouth/people/ettvard-needle.md) eavesdropping network now feeds Bror as a side channel. Needle does not know. After Needle's [week 6 kidnapping](../20-Factions/party/activity/week_6/split-leads-after-the-counting-house.md), the channel may now be picking up his captors instead.
+
+## See also
+
+- [Party — Attune to the Whispering Stone](../20-Factions/party/activity/week_2/attune-to-the-whispering-stone.md)
+- [Bror "The Shadow Stone"](../20-Factions/party/people/bror.md)
+- [Ettvard Needle](../20-Factions/baldurs-mouth/people/ettvard-needle.md)
+- [Session 20](../50-Sessions/session_20/player_summary.md)


### PR DESCRIPTION
## Summary

Closes #62.

- Populate \`60-Threads/\` with one file per dangling arc (9 threads) plus a one-row-per-thread index in \`60-Threads/README.md\`, so the \`dm-scene\` skill (and a DM eyeballing it directly) can answer "what's owed, by whom, and when does it come due" in a single read instead of mining \`20-Factions/party/summary.md\` prose.
- Rewrite \`60-Threads/CONTRIBUTING.md\` to match the new file/frontmatter shape (slug, status, introduced, owed_by, owed_to, due) and add a "when to open a thread" rule.
- Add \`60-Threads/README.md\` to the \`dm-scene\` skill's warm-up reads.

### Initial population

All sourced from canonical files — no invention:

| Thread | Source |
|---|---|
| Two unpaid fey bargains to the mirror-tent proprietor (Elia, Bror) | session_10 / week 3 |
| Nine-Fingers Keene's pending verdict on the Vex killing | session_15 / week 5 |
| The Whispering Stone's passive listening through Bror | session_8 attune, session_20 network |
| The Karak-Dur cipher | session_12 / week 5 |
| The Underdark psionic star-chart (un-decoded) | session_12 / week 5 |
| The Credential of Balduran's "old company tradition" | session_21 / week 5 |
| The Consortium propaganda cart the Consortium does not know it lost | session_1 / week 1 |
| Errinthal's secret funding of Mad Meggan | session_20 / week 5 |
| The Symbian intellect-devourer offer Bror heard | session_12 / week 5 |

## Test plan

- [x] All inter-doc links in \`60-Threads/*.md\` resolve to existing files (verified by walking every relative \`.md\` link).
- [x] Each thread file links back to a session, faction \`activity/\`, party \`activity/\`, or NPC page that established it.
- [x] \`60-Threads/README.md\` index has one row per thread with \`Owed by\` / \`Owed to\` / \`Status\` / \`Due\` columns aligned with each file's frontmatter.
- [x] \`dm-scene\` SKILL.md warm-up reads now include \`60-Threads/README.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)