### PR TITLE
Add 8 implicit threads surfaced from week 6 and prior

### DIFF
--- a/60-Threads/README.md
+++ b/60-Threads/README.md
@@ -17,3 +17,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for file shape and graduation rules.
 | [The propaganda cart the Consortium does not know it lost](consortium-propaganda-cart.md) | party | chionthar-consortium | open | when Consortium notices, or party publishes |
 | [Errinthal's secret funding of Mad Meggan](errinthal-funds-meggan.md) | party | mad-meggan | open | when party shows the receipts |
 | [The Symbian intellect-devourer offer Bror heard](symbian-intellect-devourer-offer.md) | bror | the-skittering-beetle | open | terms uncertain |
+| [Rescue Ettvard Needle from Tumbledown](rescue-ettvard-from-tumbledown.md) | party | ettvard-needle | open | fast — Board is canceling Credentials |
+| [Produce a sentient secret-source for Mother Nocturne](sentient-secret-for-mother-nocturne.md) | bror | mother-nocturne | open | until paid |
+| [Identify the Hellrider mole](hellrider-mole.md) | takers-of-the-tithe | hellriders-of-new-elturel | open | next breach kills another asset |
+| [Bror's voice sold to the Skittering Beetle](brors-voice-to-the-beetle.md) | bror | the-skittering-beetle | open | Beetle's terms |
+| [The Skittering Beetle's future contract](beetle-future-contract.md) | party | the-skittering-beetle | open | Beetle will surface to transact |
+| [Eric the imprisoned patriarch's offer](eric-upper-city-candlekeep-offer.md) | eric | party | open | mid-game investment |
+| [Alfira's great debt](alfira-great-debt.md) | the-ember | party | open | open |
+| [Lyra Sunstone's personal debt](lyra-sunstone-personal-debt.md) | lyra-sunstone | party | open | partially redeemed; balance open |

--- a/60-Threads/alfira-great-debt.md
+++ b/60-Threads/alfira-great-debt.md
@@ -1,0 +1,20 @@
+---
+name: alfira-great-debt
+description: The Ember owes the party a "great debt" for her revival on Dusthawk Hill after Singa's soul-link nearly killed her.
+status: open
+introduced: session_26 / week_6
+owed_by: the-ember
+owed_to: party
+due: open — Phoenix Gate construction is underway; she is now a faction-leader debtor
+---
+
+# Alfira's great debt
+
+In week 6, Singa's soul-link mirrored Counting-House damage onto [Alfira](../20-Factions/followers-of-the-phoenix/people/the-ember.md) until she died over the obsidian pit. Kaelan revived her with a 300-gp diamond Bror found in the pit, and the party walked her down the Hill to rest at the Plowman. The end-of-week leverage tally records "Alfira's personal 'great debt' owed back to the party" — meaning the leader of the [Followers of the Phoenix](../20-Factions/followers-of-the-phoenix/summary.md), now disciplined and building, owes them at faction scale.
+
+## See also
+
+- [Party — Storm Dusthawk Hill](../20-Factions/party/activity/week_6/storm-dusthawk-hill.md)
+- [The Ember (Alfira)](../20-Factions/followers-of-the-phoenix/people/the-ember.md)
+- [Followers of the Phoenix](../20-Factions/followers-of-the-phoenix/summary.md)
+- [Session 26](../50-Sessions/session_26/player_summary.md)

--- a/60-Threads/beetle-future-contract.md
+++ b/60-Threads/beetle-future-contract.md
@@ -1,0 +1,19 @@
+---
+name: beetle-future-contract
+description: The Skittering Beetle accepted the physical Tithe Ledger in trade for the party's lives; the page treats the party as "a future business contact," contract on the books.
+status: open
+introduced: session_26 / week_6
+owed_by: party
+owed_to: the-skittering-beetle
+due: open — Beetle will surface to transact
+---
+
+# The Skittering Beetle's future contract
+
+At the brink of a TPK in [the Counting House](../20-Factions/party/activity/week_6/storm-dusthawk-hill.md), [the Skittering Beetle](../20-Factions/takers-of-the-tithe/people/the-skittering-beetle.md) offered Elia the trade: surrender the physical Tithe Ledger, all curses lift and Singa freezes momentarily. Elia agreed. The Beetle now holds the Ledger and reads the party as "a future business contact rather than an enemy." The form of the next contract is not specified — fairness-based, transactional, structurally similar to the [mirror-tent fey bargains](fey-bargains-elia-bror.md).
+
+## See also
+
+- [Party — Storm Dusthawk Hill](../20-Factions/party/activity/week_6/storm-dusthawk-hill.md)
+- [The Skittering Beetle](../20-Factions/takers-of-the-tithe/people/the-skittering-beetle.md)
+- [Sessions 25–26](../50-Sessions/session_25/player_summary.md)

--- a/60-Threads/brors-voice-to-the-beetle.md
+++ b/60-Threads/brors-voice-to-the-beetle.md
@@ -1,0 +1,20 @@
+---
+name: brors-voice-to-the-beetle
+description: Bror sold his voice to the Skittering Beetle at the third Dusthawk Hill cairn ("hoarding silence"); term not stated.
+status: open
+introduced: session_25 / week_6
+owed_by: bror
+owed_to: the-skittering-beetle
+due: open — Beetle operates on fairness; expect a rematerialization on its terms
+---
+
+# Bror's voice sold to the Skittering Beetle
+
+At the third of the Four Cairns gating the ascent of Dusthawk Hill, [the Skittering Beetle](../20-Factions/takers-of-the-tithe/people/the-skittering-beetle.md) accused Bror of "hoarding silence" and offered the cairn-bargain. Bror accepted and [sold his voice](../20-Factions/party/activity/week_6/storm-dusthawk-hill.md). The summit Tithe-Ledger trade later in the same session lifted *every curse* the cairns laid — but the canon page on the Beetle separately describes the cairn-bargains as paid resources rather than curses, and term/duration are not stated. The party should expect to see the Beetle again, "particularly given their two outstanding fey bargains with the mirror-tent proprietor, which look structurally similar."
+
+## See also
+
+- [Party — Storm Dusthawk Hill](../20-Factions/party/activity/week_6/storm-dusthawk-hill.md)
+- [The Skittering Beetle](../20-Factions/takers-of-the-tithe/people/the-skittering-beetle.md)
+- [Bror "The Shadow Stone"](../20-Factions/party/people/bror.md)
+- [Session 25](../50-Sessions/session_25/player_summary.md)

--- a/60-Threads/eric-upper-city-candlekeep-offer.md
+++ b/60-Threads/eric-upper-city-candlekeep-offer.md
@@ -1,0 +1,19 @@
+---
+name: eric-upper-city-candlekeep-offer
+description: Eric, framed-patriarch prisoner at the New Elturel stockade, has offered the party future Upper City *or* Candlekeep access in exchange for help proving his brothers framed him.
+status: open
+introduced: session_25 / week_6
+owed_by: eric
+owed_to: party
+due: open — mid-game investment; he has no leverage in the city today
+---
+
+# Eric the imprisoned patriarch's offer
+
+[Eric](../20-Factions/peerage-of-blood/people/eric.md), a minor patriarch held at the [Hellrider stockade in New Elturel](../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md) on framed embezzlement charges, has [offered the party](../50-Sessions/session_25/player_summary.md) future access to the **Upper City *or* Candlekeep** in exchange for help proving his brothers framed him to cut him out of the family inheritance. He is low-maintenance, well-read, and has independently reconstructed both Singa's "geometry of debt" working and the Zhentarim's sewer tax-records theft — he is intellectually the most useful prisoner in the stockade, with no leverage in the city today.
+
+## See also
+
+- [Eric](../20-Factions/peerage-of-blood/people/eric.md)
+- [Peerage of Blood](../20-Factions/peerage-of-blood/summary.md)
+- [Session 25](../50-Sessions/session_25/player_summary.md)

--- a/60-Threads/hellrider-mole.md
+++ b/60-Threads/hellrider-mole.md
@@ -1,0 +1,20 @@
+---
+name: hellrider-mole
+description: A Takers insider on the Hellrider supply line poisoned the captured Reaper at the High Rider's Stand; the corrupt cook was the hand, not the mole.
+status: open
+introduced: session_24 / week_6
+owed_by: takers-of-the-tithe (the mole's handler)
+owed_to: hellriders-of-new-elturel
+due: open — next breach kills another Hellrider asset
+---
+
+# Identify the Hellrider mole
+
+In week 6 a corrupt cook on the Hellrider supply line was [paid forty platinum and the promise of a clean death later](../20-Factions/takers-of-the-tithe/activity/week_6/the-prison-silence.md) to slip necrotic poison into the captured Reaper's evening rations at the [High Rider's Stand](../30-Places/sword-coast/baldurs-gate/outer-city/new-elturel.md). The Reaper died with his soul sealed in an obsidian gem the cook smuggled out in his apron pocket. The cook is a hand, not the handler — Singa's cell has demonstrated logistical infiltration inside Alena's camp, and the actual mole on the supply line is unidentified.
+
+## See also
+
+- [Takers of the Tithe — The Prison Silence](../20-Factions/takers-of-the-tithe/activity/week_6/the-prison-silence.md)
+- [The Collector](../20-Factions/takers-of-the-tithe/people/the-collector.md)
+- [High Watcher Alena](../20-Factions/hellriders-of-new-elturel/people/high-watcher-alena.md)
+- [Session 24](../50-Sessions/session_24/player_summary.md)

--- a/60-Threads/lyra-sunstone-personal-debt.md
+++ b/60-Threads/lyra-sunstone-personal-debt.md
@@ -1,0 +1,19 @@
+---
+name: lyra-sunstone-personal-debt
+description: Lyra Sunstone owes the party a significant personal debt for restoring her Hellrider identity from Lucretius's Feywild collection.
+status: open
+introduced: session_11 / week_3
+owed_by: lyra-sunstone
+owed_to: party
+due: open — already partially redeemed in week 5 with Hellrider surplus gear
+---
+
+# Lyra Sunstone's personal debt
+
+In week 3, [Lyra Sunstone](../20-Factions/hellriders-of-new-elturel/people/lyra-sunstone.md) traded her *Memories of Elturel's Fall* to [Lucretius](../20-Factions/carnival-of-whispers/people/lucretius.md) at the [Circus of the Last Days](../20-Factions/carnival-of-whispers/activity/week_3/sowing-sweet-sorrows.md), losing her Hellrider identity entirely; the party [won her memory back](../20-Factions/party/activity/week_3/win-lyras-memory-from-lucretius.md) by answering Lucretius's three riddles, and she now owes a *significant* personal debt. In week 5 she tendered Hellrider surplus on the doorstep of the Pilgrim's Parchment as partial payment — full plate to Kaelan, leather and a balanced greatsword to Spark — but the larger debt remains. Her experience also makes her a hard-won expert on fey bargains within the Hellrider command.
+
+## See also
+
+- [Lyra Sunstone](../20-Factions/hellriders-of-new-elturel/people/lyra-sunstone.md)
+- [Party — Win Lyra's Memory from Lucretius](../20-Factions/party/activity/week_3/win-lyras-memory-from-lucretius.md)
+- [Party — The Pilgrim's Parchment Buy](../20-Factions/party/activity/week_5/the-pilgrims-parchment-buy.md)

--- a/60-Threads/rescue-ettvard-from-tumbledown.md
+++ b/60-Threads/rescue-ettvard-from-tumbledown.md
@@ -1,0 +1,19 @@
+---
+name: rescue-ettvard-from-tumbledown
+description: Ettvard Needle is missing; a hidden note in the ransacked Mouth print shop hints he fled to the Tumbledown crypts under the smoking crater the party left the day before.
+status: open
+introduced: session_27 / week_6
+owed_by: party
+owed_to: ettvard-needle
+due: open — fast; the Interim Management Board is already canceling Credential audiences
+---
+
+# Rescue Ettvard Needle from Tumbledown
+
+After the [Counting House battle](../20-Factions/party/activity/week_6/storm-dusthawk-hill.md), Kaelan crossed to Heapside to bring [Ettvard Needle](../20-Factions/baldurs-mouth/people/ettvard-needle.md) the Singa-cult exposé and found the *Baldur's Mouth* [print shop ransacked](../20-Factions/party/activity/week_6/split-leads-after-the-counting-house.md) and Needle gone. A hidden note in the wreckage hints he has fled to the dark crypts under [Tumbledown](../30-Places/sword-coast/baldurs-gate/outer-city/tumbledown-and-floodway.md), on the western bank of Dusthawk Hill — *just where the party left a smoking crater and a pit of obsidian shards*. The Reverse Siege strategy is on hold until the press contact is verified alive and willing.
+
+## See also
+
+- [Party — Split Leads After the Counting House](../20-Factions/party/activity/week_6/split-leads-after-the-counting-house.md)
+- [Ettvard Needle](../20-Factions/baldurs-mouth/people/ettvard-needle.md)
+- [Session 27](../50-Sessions/session_27/player_summary.md)

--- a/60-Threads/sentient-secret-for-mother-nocturne.md
+++ b/60-Threads/sentient-secret-for-mother-nocturne.md
@@ -1,0 +1,20 @@
+---
+name: sentient-secret-for-mother-nocturne
+description: Mother Nocturne demands the physical sentient source of Bror's secret, not the words; the Whispering Stone debt remains unpaid.
+status: open
+introduced: session_27 / week_6
+owed_by: bror
+owed_to: mother-nocturne
+due: open — debt accrues until paid
+---
+
+# Produce a sentient secret-source for Mother Nocturne
+
+In week 6 Bror, Elia, and Finn rode for the Penumbra Playhouse to deliver the secret Bror owes [Mother Nocturne](../20-Factions/silent-shroud/people/mother-nocturne.md) under the [Whispering Stone bargain](../20-Factions/party/activity/week_2/attune-to-the-whispering-stone.md). The Night Mother [refused the words and demanded the physical manifestation](../20-Factions/party/activity/week_6/split-leads-after-the-counting-house.md) — *the sentient source*. Until Bror can deliver, the [Silent Shroud](../20-Factions/silent-shroud/summary.md)'s claim on him sits open and the intelligence channel runs only one way.
+
+## See also
+
+- [Party — Split Leads After the Counting House](../20-Factions/party/activity/week_6/split-leads-after-the-counting-house.md)
+- [Bror "The Shadow Stone"](../20-Factions/party/people/bror.md)
+- [Mother Nocturne](../20-Factions/silent-shroud/people/mother-nocturne.md)
+- [Session 27](../50-Sessions/session_27/player_summary.md)


### PR DESCRIPTION
## Summary

Stacked on top of #66.

Issue #62 enumerated 9 starter threads. The week-6 paragraph in \`20-Factions/party/summary.md\` explicitly names four more "open threads" the issue did not list, and four additional debts/contracts in the canon fit the same shape. All eight are sourced from existing canonical files; no invented detail.

### Threads added

**Week-6 cliffhangers (canon-stated open threads):**
- \`rescue-ettvard-from-tumbledown\` — Mouth print shop ransacked; hidden note hints Tumbledown crypts.
- \`sentient-secret-for-mother-nocturne\` — Night Mother demands the physical manifestation, not the words.
- \`hellrider-mole\` — the corrupt cook was the hand; the supply-line mole is unidentified.

**Week-6 paid resources / contracts on the books:**
- \`brors-voice-to-the-beetle\` — sold at the third Dusthawk Hill cairn.
- \`beetle-future-contract\` — Beetle holds the Tithe Ledger; party is "a future business contact."

**NPC debts owed *to* the party:**
- \`eric-upper-city-candlekeep-offer\` — Upper City *or* Candlekeep access in exchange for proving the framing.
- \`alfira-great-debt\` — for the Dusthawk Hill revival.
- \`lyra-sunstone-personal-debt\` — for the Feywild memory restoration; partially redeemed in week 5.

Skipped (look dormant rather than dangling): Roah Moonglow's warrant-erasure offer (warrant cooled in week 3); Vex's "silence Gareth" contract (Vex is dead). Happy to add these with \`status: dormant\` if you want them visible.

Skipped (lore mystery, not debt-shaped): the Shard of the First Scribe / God of Naming. Open to adding — but the \`owed_by\` / \`owed_to\` columns won't fit it cleanly.

## Test plan

- [x] All inter-doc links in \`60-Threads/*.md\` resolve to existing files.
- [x] Each new thread file links back to a session, faction \`activity/\`, party \`activity/\`, or NPC page that established it.
- [x] \`60-Threads/README.md\` index extended with one row per new thread, frontmatter and table aligned.
- [x] Stacked: base = \`bfollin-kiso/issue-62\`. Will rebase to \`main\` automatically once #66 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)